### PR TITLE
Fix glossary bug in DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -527,6 +527,7 @@ able to accomplish most of the tasks faster using commands than using the mouse.
 * **Customer**: A contact detail. Contains information about the customer, and a list of commissions.
 * **Commission**: An art piece requested by a customer that has been delivered or is in progress. Contains specifics about the commission and a list of iterations.
 * **Iteration**: A single version of a commission. Contains an image and a text comment on the image. 
+
 --------------------------------------------------------------------------------------------------------------------
 
 ## **Appendix: Instructions for manual testing**


### PR DESCRIPTION
Stop last glossary item from rendering as header on GH pages.

https://ay2223s1-cs2103t-w11-3.github.io/tp/DeveloperGuide.html#glossary
![image](https://user-images.githubusercontent.com/34371483/193251498-6c04f319-95fc-49bb-aaef-06c27fc97868.png)

Markdown is getting misinterpreted as [a heading (alternate syntax)](https://www.markdownguide.org/basic-syntax#headings:~:text=Heading%20level%201-,Heading%20level%202,-%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D)
