### PR TITLE
Update Tag regex validation to allow spaces

### DIFF
--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -9,8 +9,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric or spaces";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum} ]+";
 
     public final String tagName;
 


### PR DESCRIPTION
Tags currently do not allow spaces. Let's enable it so our tags can have more variation e.g `neon palette` in #75 

Note that leading/trailing whitespace should be handled in `ParserUtil.java`