### PR TITLE
Ui: change commission tag to orange

### DIFF
--- a/src/main/java/seedu/address/ui/CommissionCard.java
+++ b/src/main/java/seedu/address/ui/CommissionCard.java
@@ -58,7 +58,11 @@ public class CommissionCard extends UiPart<Region> {
         completionStatus.setText("completed: " + commission.getCompletionStatus().isCompleted);
         commission.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
-                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+                .forEach(tag -> {
+                    Label tagLabel = new Label(tag.tagName);
+                    tagLabel.setStyle(tagLabel.getStyle() + " -fx-background-color: #F26417;");
+                    tags.getChildren().add(tagLabel);
+                });
     }
 
     @Override


### PR DESCRIPTION
This is to make it match Ui.png.

The orange used is #F26417

<img width="799" alt="image" src="https://user-images.githubusercontent.com/34371483/194788446-dcfa6292-1cd9-4139-a790-b9dcbbe776f5.png">
