### PR TITLE
Fix: Wrong parseTitle ParseException

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -116,7 +116,7 @@ public class ParserUtil {
         requireNonNull(title);
         String trimmedTitle = title.trim();
         if (!Title.isValidTitle(trimmedTitle)) {
-            throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
+            throw new ParseException(Title.MESSAGE_CONSTRAINTS);
         }
         return new Title(trimmedTitle);
     }


### PR DESCRIPTION
`ParserUtil#parseTitle` was wrongly throwing a `ParseException` with exception message for `Phone` constraints.

As as result, when you enter an `addcom` command with an invalid title (one that contains non-alphumerical characters like punctuation), the result displays "Phone numbers should only contain numbers, and it should be at least 3 digits long". This PR fixes this bug.