### PR TITLE
Test: add delcom tests

### DIFF
--- a/src/test/java/seedu/address/logic/commands/DeleteCommissionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommissionCommandTest.java
@@ -1,0 +1,77 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.TypicalCommissions.DOG_PRODUCER;
+import static seedu.address.testutil.TypicalCustomers.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.commission.Commission;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code DeleteCommissionCommand}.
+ */
+class DeleteCommissionCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_noSelectedCustomer_throwsCommandException() {
+        // initialise an empty model manager since ModelManager#selectCustomer does not allow me to select null
+        model = new ModelManager();
+        assertCommandFailure(new DeleteCommissionCommand(INDEX_FIRST), model, Messages.MESSAGE_NO_ACTIVE_CUSTOMER);
+    }
+
+    @Test
+    public void execute_validIndex_success() {
+        model.selectCustomer(model.getFilteredCustomerList().get(0));
+        model.getSelectedCustomer().getValue().addCommission(
+                DOG_PRODUCER.apply(model.getSelectedCustomer().getValue()));
+        Commission commissionToDelete = model.getFilteredCommissionList().get(0);
+        DeleteCommissionCommand deleteCommissionCommand = new DeleteCommissionCommand(INDEX_FIRST);
+
+        String expectedMessage = String.format(DeleteCommissionCommand.MESSAGE_DELETE_COMMISSION_SUCCESS,
+                commissionToDelete);
+
+        CommandResult result = assertDoesNotThrow(() -> deleteCommissionCommand.execute(model));
+
+        assertEquals(result.getFeedbackToUser(), expectedMessage);
+        assertFalse(model.getSelectedCustomer().getValue().getCommissions().contains(commissionToDelete));
+    }
+
+    @Test
+    public void execute_indexTooHigh_throwsCommandException() {
+        model.selectCustomer(model.getFilteredCustomerList().get(0));
+        DeleteCommissionCommand deleteCommissionCommand = new DeleteCommissionCommand(INDEX_FIRST);
+        assertCommandFailure(deleteCommissionCommand, model, Messages.MESSAGE_INVALID_COMMISSION_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        DeleteCommissionCommand deleteFirstCommand = new DeleteCommissionCommand(INDEX_FIRST);
+        DeleteCommissionCommand deleteSecondCommand = new DeleteCommissionCommand(INDEX_SECOND);
+
+        // same object -> returns true
+        assertEquals(deleteFirstCommand, deleteFirstCommand);
+
+        // same values -> returns true
+        DeleteCommissionCommand deleteFirstCommandCopy = new DeleteCommissionCommand(INDEX_FIRST);
+        assertEquals(deleteFirstCommand, deleteFirstCommandCopy);
+
+        // null -> returns false
+        assertNotEquals(deleteFirstCommand, null);
+
+        // different commission -> returns false
+        assertNotEquals(deleteFirstCommand, deleteSecondCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/DeleteCustomerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCustomerCommandTest.java
@@ -7,8 +7,8 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showCustomerAtIndex;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CUSTOMERS;
 import static seedu.address.testutil.TypicalCustomers.getTypicalAddressBook;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CUSTOMER;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CUSTOMER;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
 
 import org.junit.jupiter.api.Test;
 
@@ -29,8 +29,8 @@ public class DeleteCustomerCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        Customer customerToDelete = model.getFilteredCustomerList().get(INDEX_FIRST_CUSTOMER.getZeroBased());
-        DeleteCustomerCommand deleteCommand = new DeleteCustomerCommand(INDEX_FIRST_CUSTOMER);
+        Customer customerToDelete = model.getFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
+        DeleteCustomerCommand deleteCommand = new DeleteCustomerCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(DeleteCustomerCommand.MESSAGE_DELETE_CUSTOMER_SUCCESS, customerToDelete);
 
@@ -50,10 +50,10 @@ public class DeleteCustomerCommandTest {
 
     @Test
     public void execute_validIndexFilteredList_success() {
-        showCustomerAtIndex(model, INDEX_FIRST_CUSTOMER);
+        showCustomerAtIndex(model, INDEX_FIRST);
 
-        Customer customerToDelete = model.getFilteredCustomerList().get(INDEX_FIRST_CUSTOMER.getZeroBased());
-        DeleteCustomerCommand deleteCommand = new DeleteCustomerCommand(INDEX_FIRST_CUSTOMER);
+        Customer customerToDelete = model.getFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
+        DeleteCustomerCommand deleteCommand = new DeleteCustomerCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(DeleteCustomerCommand.MESSAGE_DELETE_CUSTOMER_SUCCESS, customerToDelete);
 
@@ -66,9 +66,9 @@ public class DeleteCustomerCommandTest {
 
     @Test
     public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showCustomerAtIndex(model, INDEX_FIRST_CUSTOMER);
+        showCustomerAtIndex(model, INDEX_FIRST);
 
-        Index outOfBoundIndex = INDEX_SECOND_CUSTOMER;
+        Index outOfBoundIndex = INDEX_SECOND;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getCustomerList().size());
 
@@ -79,14 +79,14 @@ public class DeleteCustomerCommandTest {
 
     @Test
     public void equals() {
-        DeleteCustomerCommand deleteFirstCommand = new DeleteCustomerCommand(INDEX_FIRST_CUSTOMER);
-        DeleteCustomerCommand deleteSecondCommand = new DeleteCustomerCommand(INDEX_SECOND_CUSTOMER);
+        DeleteCustomerCommand deleteFirstCommand = new DeleteCustomerCommand(INDEX_FIRST);
+        DeleteCustomerCommand deleteSecondCommand = new DeleteCustomerCommand(INDEX_SECOND);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCustomerCommand deleteFirstCommandCopy = new DeleteCustomerCommand(INDEX_FIRST_CUSTOMER);
+        DeleteCustomerCommand deleteFirstCommandCopy = new DeleteCustomerCommand(INDEX_FIRST);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -11,8 +11,8 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showCustomerAtIndex;
 import static seedu.address.testutil.TypicalCustomers.getTypicalAddressBook;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CUSTOMER;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CUSTOMER;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
 
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +38,7 @@ public class EditCommandTest {
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Customer editedCustomer = new CustomerBuilder().build();
         EditCustomerDescriptor descriptor = new EditCustomerDescriptorBuilder(editedCustomer).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_CUSTOMER, descriptor);
+        EditCommand editCommand = new EditCommand(INDEX_FIRST, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CUSTOMER_SUCCESS, editedCustomer);
 
@@ -71,8 +71,8 @@ public class EditCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_CUSTOMER, new EditCustomerDescriptor());
-        Customer customerInFilteredList = model.getFilteredCustomerList().get(INDEX_FIRST_CUSTOMER.getZeroBased());
+        EditCommand editCommand = new EditCommand(INDEX_FIRST, new EditCustomerDescriptor());
+        Customer customerInFilteredList = model.getFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
         Customer editedCustomer = new CustomerBuilder(customerInFilteredList).withoutAddress().build();
         model.setCustomer(customerInFilteredList, editedCustomer);
 
@@ -85,11 +85,11 @@ public class EditCommandTest {
 
     @Test
     public void execute_filteredList_success() {
-        showCustomerAtIndex(model, INDEX_FIRST_CUSTOMER);
+        showCustomerAtIndex(model, INDEX_FIRST);
 
-        Customer customerInFilteredList = model.getFilteredCustomerList().get(INDEX_FIRST_CUSTOMER.getZeroBased());
+        Customer customerInFilteredList = model.getFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
         Customer editedCustomer = new CustomerBuilder(customerInFilteredList).withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_CUSTOMER,
+        EditCommand editCommand = new EditCommand(INDEX_FIRST,
                 new EditCustomerDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CUSTOMER_SUCCESS, editedCustomer);
@@ -102,20 +102,20 @@ public class EditCommandTest {
 
     @Test
     public void execute_duplicateCustomerUnfilteredList_failure() {
-        Customer firstCustomer = model.getFilteredCustomerList().get(INDEX_FIRST_CUSTOMER.getZeroBased());
+        Customer firstCustomer = model.getFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
         EditCustomerDescriptor descriptor = new EditCustomerDescriptorBuilder(firstCustomer).build();
-        EditCommand editCommand = new EditCommand(INDEX_SECOND_CUSTOMER, descriptor);
+        EditCommand editCommand = new EditCommand(INDEX_SECOND, descriptor);
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_CUSTOMER);
     }
 
     @Test
     public void execute_duplicateCustomerFilteredList_failure() {
-        showCustomerAtIndex(model, INDEX_FIRST_CUSTOMER);
+        showCustomerAtIndex(model, INDEX_FIRST);
 
         // edit customer in filtered list into a duplicate in address book
-        Customer customerInList = model.getAddressBook().getCustomerList().get(INDEX_SECOND_CUSTOMER.getZeroBased());
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_CUSTOMER,
+        Customer customerInList = model.getAddressBook().getCustomerList().get(INDEX_SECOND.getZeroBased());
+        EditCommand editCommand = new EditCommand(INDEX_FIRST,
                 new EditCustomerDescriptorBuilder(customerInList).build());
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_CUSTOMER);
@@ -136,8 +136,8 @@ public class EditCommandTest {
      */
     @Test
     public void execute_invalidCustomerIndexFilteredList_failure() {
-        showCustomerAtIndex(model, INDEX_FIRST_CUSTOMER);
-        Index outOfBoundIndex = INDEX_SECOND_CUSTOMER;
+        showCustomerAtIndex(model, INDEX_FIRST);
+        Index outOfBoundIndex = INDEX_SECOND;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getCustomerList().size());
 
@@ -149,11 +149,11 @@ public class EditCommandTest {
 
     @Test
     public void equals() {
-        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_CUSTOMER, DESC_AMY);
+        final EditCommand standardCommand = new EditCommand(INDEX_FIRST, DESC_AMY);
 
         // same values -> returns true
         EditCustomerDescriptor copyDescriptor = new EditCustomerDescriptor(DESC_AMY);
-        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_CUSTOMER, copyDescriptor);
+        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST, copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -166,10 +166,10 @@ public class EditCommandTest {
         assertFalse(standardCommand.equals(new ClearCommand()));
 
         // different index -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_CUSTOMER, DESC_AMY)));
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND, DESC_AMY)));
 
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_CUSTOMER, DESC_BOB)));
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST, DESC_BOB)));
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showCustomerAtIndex;
 import static seedu.address.testutil.TypicalCustomers.getTypicalAddressBook;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CUSTOMER;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,7 +33,7 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
-        showCustomerAtIndex(model, INDEX_FIRST_CUSTOMER);
+        showCustomerAtIndex(model, INDEX_FIRST);
         assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/OpenCustomerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/OpenCustomerCommandTest.java
@@ -6,8 +6,8 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showCustomerAtIndex;
 import static seedu.address.testutil.TypicalCustomers.getTypicalAddressBook;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CUSTOMER;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CUSTOMER;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
 
 import org.junit.jupiter.api.Test;
 
@@ -28,8 +28,8 @@ public class OpenCustomerCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        Customer customerToDelete = model.getFilteredCustomerList().get(INDEX_FIRST_CUSTOMER.getZeroBased());
-        OpenCustomerCommand openCommand = new OpenCustomerCommand(INDEX_FIRST_CUSTOMER);
+        Customer customerToDelete = model.getFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
+        OpenCustomerCommand openCommand = new OpenCustomerCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(OpenCustomerCommand.MESSAGE_OPEN_CUSTOMER_SUCCESS, customerToDelete);
 
@@ -48,24 +48,24 @@ public class OpenCustomerCommandTest {
 
     @Test
     public void execute_validIndexFilteredList_success() {
-        showCustomerAtIndex(model, INDEX_FIRST_CUSTOMER);
+        showCustomerAtIndex(model, INDEX_FIRST);
 
-        Customer customerToOpen = model.getFilteredCustomerList().get(INDEX_FIRST_CUSTOMER.getZeroBased());
-        OpenCustomerCommand openCommand = new OpenCustomerCommand(INDEX_FIRST_CUSTOMER);
+        Customer customerToOpen = model.getFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
+        OpenCustomerCommand openCommand = new OpenCustomerCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(OpenCustomerCommand.MESSAGE_OPEN_CUSTOMER_SUCCESS, customerToOpen);
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-        showCustomerAtIndex(expectedModel, INDEX_FIRST_CUSTOMER);
+        showCustomerAtIndex(expectedModel, INDEX_FIRST);
 
         assertCommandSuccess(openCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showCustomerAtIndex(model, INDEX_FIRST_CUSTOMER);
+        showCustomerAtIndex(model, INDEX_FIRST);
 
-        Index outOfBoundIndex = INDEX_SECOND_CUSTOMER;
+        Index outOfBoundIndex = INDEX_SECOND;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getCustomerList().size());
 
@@ -76,14 +76,14 @@ public class OpenCustomerCommandTest {
 
     @Test
     public void equals() {
-        OpenCustomerCommand openFirstCommand = new OpenCustomerCommand(INDEX_FIRST_CUSTOMER);
-        OpenCustomerCommand openSecondCommand = new OpenCustomerCommand(INDEX_SECOND_CUSTOMER);
+        OpenCustomerCommand openFirstCommand = new OpenCustomerCommand(INDEX_FIRST);
+        OpenCustomerCommand openSecondCommand = new OpenCustomerCommand(INDEX_SECOND);
 
         // same object -> returns true
         assertTrue(openFirstCommand.equals(openFirstCommand));
 
         // same values -> returns true
-        OpenCustomerCommand openFirstCommandCopy = new OpenCustomerCommand(INDEX_FIRST_CUSTOMER);
+        OpenCustomerCommand openFirstCommandCopy = new OpenCustomerCommand(INDEX_FIRST);
         assertTrue(openFirstCommand.equals(openFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CUSTOMER;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
 import java.util.Arrays;
 import java.util.List;
@@ -51,15 +51,15 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_deleteCustomer() throws Exception {
         DeleteCustomerCommand command = (DeleteCustomerCommand) parser.parseCommand(
-                DeleteCustomerCommand.COMMAND_WORD + " " + INDEX_FIRST_CUSTOMER.getOneBased());
-        assertEquals(new DeleteCustomerCommand(INDEX_FIRST_CUSTOMER), command);
+                DeleteCustomerCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased());
+        assertEquals(new DeleteCustomerCommand(INDEX_FIRST), command);
     }
 
     @Test
     public void parseCommand_openCustomer() throws Exception {
         OpenCustomerCommand command = (OpenCustomerCommand) parser.parseCommand(
-                OpenCustomerCommand.COMMAND_WORD + " " + INDEX_FIRST_CUSTOMER.getOneBased());
-        assertEquals(new OpenCustomerCommand(INDEX_FIRST_CUSTOMER), command);
+                OpenCustomerCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased());
+        assertEquals(new OpenCustomerCommand(INDEX_FIRST), command);
     }
 
     @Test
@@ -67,8 +67,8 @@ public class AddressBookParserTest {
         Customer customer = new CustomerBuilder().build();
         EditCustomerDescriptor descriptor = new EditCustomerDescriptorBuilder(customer).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_CUSTOMER.getOneBased() + " " + CustomerUtil.getEditCustomerDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(INDEX_FIRST_CUSTOMER, descriptor), command);
+                + INDEX_FIRST.getOneBased() + " " + CustomerUtil.getEditCustomerDescriptorDetails(descriptor));
+        assertEquals(new EditCommand(INDEX_FIRST, descriptor), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCustomerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCustomerCommandParserTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CUSTOMER;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +22,7 @@ public class DeleteCustomerCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCustomerCommand() {
-        assertParseSuccess(parser, "1", new DeleteCustomerCommand(INDEX_FIRST_CUSTOMER));
+        assertParseSuccess(parser, "1", new DeleteCustomerCommand(INDEX_FIRST));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -27,9 +27,9 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CUSTOMER;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CUSTOMER;
-import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_CUSTOMER;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD;
 
 import org.junit.jupiter.api.Test;
 
@@ -107,7 +107,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        Index targetIndex = INDEX_SECOND_CUSTOMER;
+        Index targetIndex = INDEX_SECOND;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_HUSBAND
                 + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + TAG_DESC_FRIEND;
 
@@ -121,7 +121,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_someFieldsSpecified_success() {
-        Index targetIndex = INDEX_FIRST_CUSTOMER;
+        Index targetIndex = INDEX_FIRST;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
 
         EditCustomerDescriptor descriptor = new EditCustomerDescriptorBuilder().withPhone(VALID_PHONE_BOB)
@@ -134,7 +134,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_oneFieldSpecified_success() {
         // name
-        Index targetIndex = INDEX_THIRD_CUSTOMER;
+        Index targetIndex = INDEX_THIRD;
         String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
         EditCustomerDescriptor descriptor = new EditCustomerDescriptorBuilder().withName(VALID_NAME_AMY).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
@@ -167,7 +167,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_multipleRepeatedFields_acceptsLast() {
-        Index targetIndex = INDEX_FIRST_CUSTOMER;
+        Index targetIndex = INDEX_FIRST;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
                 + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
                 + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
@@ -183,7 +183,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidValueFollowedByValidValue_success() {
         // no other valid values specified
-        Index targetIndex = INDEX_FIRST_CUSTOMER;
+        Index targetIndex = INDEX_FIRST;
         String userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
         EditCustomerDescriptor descriptor = new EditCustomerDescriptorBuilder().withPhone(VALID_PHONE_BOB).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
@@ -200,7 +200,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_resetTags_success() {
-        Index targetIndex = INDEX_THIRD_CUSTOMER;
+        Index targetIndex = INDEX_THIRD;
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
         EditCustomerDescriptor descriptor = new EditCustomerDescriptorBuilder().withTags().build();

--- a/src/test/java/seedu/address/logic/parser/OpenCustomerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/OpenCustomerCommandParserTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CUSTOMER;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +22,7 @@ public class OpenCustomerCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsOpenCustomerCommand() {
-        assertParseSuccess(parser, "1", new OpenCustomerCommand(INDEX_FIRST_CUSTOMER));
+        assertParseSuccess(parser, "1", new OpenCustomerCommand(INDEX_FIRST));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CUSTOMER;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -60,10 +60,10 @@ public class ParserUtilTest {
     @Test
     public void parseIndex_validInput_success() throws Exception {
         // No whitespaces
-        assertEquals(INDEX_FIRST_CUSTOMER, ParserUtil.parseIndex("1"));
+        assertEquals(INDEX_FIRST, ParserUtil.parseIndex("1"));
 
         // Leading and trailing whitespaces
-        assertEquals(INDEX_FIRST_CUSTOMER, ParserUtil.parseIndex("  1  "));
+        assertEquals(INDEX_FIRST, ParserUtil.parseIndex("  1  "));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalCommissions.java
+++ b/src/test/java/seedu/address/testutil/TypicalCommissions.java
@@ -20,7 +20,7 @@ import seedu.address.model.commission.Commission;
 import seedu.address.model.customer.Customer;
 
 /**
- * A utility class containing a list of {@code Customer} objects to be used in tests.
+ * A utility class containing a list of {@code Commission} objects to be used in tests.
  */
 public class TypicalCommissions {
 

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -6,7 +6,7 @@ import seedu.address.commons.core.index.Index;
  * A utility class containing a list of {@code Index} objects to be used in tests.
  */
 public class TypicalIndexes {
-    public static final Index INDEX_FIRST_CUSTOMER = Index.fromOneBased(1);
-    public static final Index INDEX_SECOND_CUSTOMER = Index.fromOneBased(2);
-    public static final Index INDEX_THIRD_CUSTOMER = Index.fromOneBased(3);
+    public static final Index INDEX_FIRST = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD = Index.fromOneBased(3);
 }


### PR DESCRIPTION
- add delcom tests
- refactor names in TypicalIndex to not be customer specific to reuse them for commissions

The reason why I am not using `assertCommandSuccess` is because if I copy the delcus tests to create an expectedModel, both model and expectedModel have the same Customer objects (from how addressbook sets its data), and deleting one commission will also modify the other model.