### PR TITLE
Fix issue with UniqueCommissionLists of different customers having the same hash

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -2,9 +2,9 @@ package seedu.address.logic;
 
 import java.nio.file.Path;
 
-import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.util.Pair;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.ObservableObject;
 import seedu.address.logic.commands.CommandResult;
@@ -38,8 +38,10 @@ public interface Logic {
     /** Returns an unmodifiable view of the filtered list of customers */
     ObservableList<Customer> getFilteredCustomerList();
 
-    /** Returns an unmodifiable view of the filtered list of commission */
-    ObservableValue<FilteredList<Commission>> getObservableFilteredCommissionList();
+    /**
+     * Returns an unmodifiable view of the filtered list of commission
+     */
+    ObservableObject<Pair<Customer, FilteredList<Commission>>> getObservableFilteredCommissionList();
     /**
      * Returns the user prefs' address book file path.
      */

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -8,9 +8,9 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.logging.Logger;
 
-import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.util.Pair;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.ObservableObject;
@@ -77,7 +77,7 @@ public class LogicManager implements Logic {
 
 
     @Override
-    public ObservableValue<FilteredList<Commission>> getObservableFilteredCommissionList() {
+    public ObservableObject<Pair<Customer, FilteredList<Commission>>> getObservableFilteredCommissionList() {
         return model.getObservableFilteredCommissionList();
     }
 
@@ -127,9 +127,12 @@ public class LogicManager implements Logic {
 
     @Override
     public void selectValidCommission() {
-        if (!model.getFilteredCommissionList().contains(model.getSelectedCommission().getValue())) {
+        FilteredList<Commission> commissions = model.getFilteredCommissionList();
+        if (commissions == null) {
+            model.selectCommission(null);
+        } else if (!commissions.contains(model.getSelectedCommission().getValue())) {
             model.updateFilteredCommissionList(PREDICATE_SHOW_ALL_COMMISSIONS);
-            List<Commission> commissions = model.getFilteredCommissionList();
+            commissions = model.getObservableFilteredCommissionList().getValue().getValue();
             model.selectCommission(commissions.size() > 0 ? commissions.get(0) : null);
         }
     }

--- a/src/main/java/seedu/address/logic/commands/AddCommissionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommissionCommand.java
@@ -65,8 +65,8 @@ public class AddCommissionCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_COMMISSION);
         }
         selectedCustomer.addCommission(newCommission);
-
         model.selectTab(GuiTab.COMMISSION);
+        model.selectCommission(newCommission);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddCustomerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCustomerCommand.java
@@ -58,6 +58,7 @@ public class AddCustomerCommand extends Command {
 
         model.addCustomer(toAdd);
         model.selectTab(GuiTab.CUSTOMER);
+        model.selectCustomer(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommissionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommissionCommand.java
@@ -46,12 +46,17 @@ public class DeleteCommissionCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_COMMISSION_DISPLAYED_INDEX);
         }
 
+        Commission selectedCommission = model.getSelectedCommission().getValue();
         Commission commissionToDelete = lastShownList.get(targetIndex.getZeroBased());
         Customer customer = commissionToDelete.getCustomer();
         customer.removeCommission(commissionToDelete);
-        model.updateFilteredCommissionList(PREDICATE_SHOW_ALL_COMMISSIONS);
         model.selectTab(GuiTab.COMMISSION);
-        model.selectCommission(null);
+        model.updateFilteredCommissionList(PREDICATE_SHOW_ALL_COMMISSIONS);
+        if (selectedCommission != null && !selectedCommission.isSameCommission(commissionToDelete)) {
+            model.selectCommission(selectedCommission);
+        } else {
+            model.selectCommission(null);
+        }
 
         return new CommandResult(String.format(MESSAGE_DELETE_COMMISSION_SUCCESS, commissionToDelete));
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteCustomerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCustomerCommand.java
@@ -42,11 +42,15 @@ public class DeleteCustomerCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_CUSTOMER_DISPLAYED_INDEX);
         }
 
+        model.selectTab(GuiTab.CUSTOMER);
+        Customer selectedCustomer = model.getSelectedCustomer().getValue();
         Customer customerToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteCustomer(customerToDelete);
+        if (!selectedCustomer.isSameCustomer(customerToDelete)) {
+            model.selectCustomer(selectedCustomer);
+        }
 
         model.updateFilteredCustomerList(PREDICATE_SHOW_ALL_CUSTOMERS);
-        model.selectTab(GuiTab.CUSTOMER);
         return new CommandResult(String.format(MESSAGE_DELETE_CUSTOMER_SUCCESS, customerToDelete));
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -3,9 +3,9 @@ package seedu.address.model;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 
-import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.util.Pair;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.ObservableObject;
 import seedu.address.model.commission.Commission;
@@ -112,12 +112,12 @@ public interface Model {
      * Returns an unmodifiable view of the list of {@code Commission} backed by the internal list of
      * {@code versionedAddressBook}
      */
-    ObservableList<Commission> getFilteredCommissionList();
+    FilteredList<Commission> getFilteredCommissionList();
 
     /**
      * Returns an observable instance of the current filtered list of {@code Commission}
      */
-    ObservableValue<FilteredList<Commission>> getObservableFilteredCommissionList();
+    ObservableObject<Pair<Customer, FilteredList<Commission>>> getObservableFilteredCommissionList();
 
     /**
      * Updates the filter of the current filtered commission list to filter by the given {@code predicate}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -185,7 +185,7 @@ public class ModelManager implements Model {
         if (filteredCustomers.size() == 0) {
             selectCustomer(null);
         } else if (hasSelectedCustomer() && filteredCustomers.stream()
-                    .noneMatch(selectedCustomer.getValue()::isSameCustomer)) {
+                .noneMatch(selectedCustomer.getValue()::isSameCustomer)) {
             selectCustomer(filteredCustomers.get(0));
         }
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedCustomer.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedCustomer.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.commission.UniqueCommissionList;
 import seedu.address.model.customer.Address;
 import seedu.address.model.customer.Customer;
 import seedu.address.model.customer.Email;
@@ -128,9 +127,8 @@ class JsonAdaptedCustomer {
 
 
         final Set<Tag> modelTags = new HashSet<>(customerTags);
-        final UniqueCommissionList customerCommissions = new UniqueCommissionList();
         Customer.CustomerBuilder customerBuilder = new Customer.CustomerBuilder(modelName, modelPhone, modelEmail,
-                modelTags).setCommissions(customerCommissions);
+                modelTags);
         modelAddress.ifPresent(customerBuilder::setAddress);
         Customer customer = customerBuilder.build();
 

--- a/src/main/java/seedu/address/ui/CommissionListPanel.java
+++ b/src/main/java/seedu/address/ui/CommissionListPanel.java
@@ -3,16 +3,17 @@ package seedu.address.ui;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 
-import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
+import javafx.util.Pair;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.ObservableObject;
 import seedu.address.model.commission.Commission;
+import seedu.address.model.customer.Customer;
 
 /**
  * Panel containing the list of commissions.
@@ -28,14 +29,14 @@ public class CommissionListPanel extends UiPart<Region> {
     /**
      * Creates a {@code CommissionListPanel} with the given {@code ObservableList}.
      */
-    public CommissionListPanel(ObservableValue<FilteredList<Commission>> observableCommissionList,
+    public CommissionListPanel(ObservableObject<Pair<Customer, FilteredList<Commission>>> observableCommissionList,
                                Consumer<Commission> selectCommission,
                                ObservableObject<Commission> selectedCommission) {
         super(FXML);
-        this.updateUI(observableCommissionList.getValue());
+        this.updateUI(observableCommissionList.getValue().getValue());
         this.selectCommission = selectCommission;
 
-        observableCommissionList.addListener((observable, oldValue, newValue) -> this.updateUI(newValue));
+        observableCommissionList.addListener((observable, oldValue, newValue) -> this.updateUI(newValue.getValue()));
         commissionListView.getSelectionModel().select(selectedCommission.getValue());
         selectedCommission.addListener(((observable, oldValue, newValue) ->
                 commissionListView.getSelectionModel().select(newValue)));

--- a/src/test/java/seedu/address/logic/commands/AddCustomerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCustomerCommandTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.ObservableObject;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ModelStub;
@@ -34,6 +35,7 @@ public class AddCustomerCommandTest {
         assertEquals(String.format(AddCustomerCommand.MESSAGE_SUCCESS, validCustomer),
                 commandResult.getFeedbackToUser());
         assertEquals(Collections.singletonList(validCustomer), modelStub.customersAdded);
+        assertEquals(validCustomer, modelStub.getSelectedCustomer().getValue());
     }
 
     @Test
@@ -93,6 +95,7 @@ public class AddCustomerCommandTest {
      */
     private static class ModelStubAcceptingCustomerAdded extends ModelStub {
         final ArrayList<Customer> customersAdded = new ArrayList<>();
+        private final ObservableObject<Customer> selectedCustomer = new ObservableObject<>();
 
         @Override
         public boolean hasCustomer(Customer customer) {
@@ -109,6 +112,16 @@ public class AddCustomerCommandTest {
         @Override
         public ReadOnlyAddressBook getAddressBook() {
             return new AddressBook();
+        }
+
+        @Override
+        public ObservableObject<Customer> getSelectedCustomer() {
+            return selectedCustomer;
+        }
+
+        @Override
+        public void selectCustomer(Customer customer) {
+            selectedCustomer.setValue(customer);
         }
     }
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -16,6 +16,8 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
+import javafx.collections.transformation.FilteredList;
+import javafx.util.Pair;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.commission.Commission;
 import seedu.address.model.customer.Customer;
@@ -120,17 +122,31 @@ public class ModelManagerTest {
     }
 
     @Test
-    public void selectCustomer_newCustomer_resetsSelectedCommission() {
+    public void selectCustomer_newCustomer_selectsNewCustomer() {
         Customer testCustomer = new CustomerBuilder(ALICE).build();
         modelManager.addCustomer(testCustomer);
         Commission testCommission = new CommissionBuilder().build(testCustomer);
         testCustomer.addCommission(testCommission);
-        modelManager.addCustomer(BENSON);
         modelManager.selectCustomer(testCustomer);
-        modelManager.selectCommission(testCommission);
-        assertEquals(testCommission, modelManager.getSelectedCommission().getValue());
+        assertEquals(testCustomer, modelManager.getSelectedCustomer().getValue());
+        modelManager.addCustomer(BENSON);
         modelManager.selectCustomer(BENSON);
+        assertEquals(BENSON, modelManager.getSelectedCustomer().getValue());
+        modelManager.selectCustomer(null);
         assertNull(modelManager.getSelectedCommission().getValue());
+    }
+
+    @Test
+    public void addCommission_emptyList_updatesObservableList() {
+        Customer aliceCopy = new CustomerBuilder(ALICE).build();
+        modelManager.selectCustomer(null);
+        Pair<Customer, FilteredList<Commission>> originalList =
+                modelManager.getObservableFilteredCommissionList().getValue();
+        modelManager.addCustomer(aliceCopy);
+        Commission testCommission = new CommissionBuilder().build(aliceCopy);
+        modelManager.selectCustomer(aliceCopy);
+        aliceCopy.addCommission(testCommission);
+        assertNotEquals(originalList, modelManager.getObservableFilteredCommissionList().getValue());
     }
 
 

--- a/src/test/java/seedu/address/model/ModelStub.java
+++ b/src/test/java/seedu/address/model/ModelStub.java
@@ -3,9 +3,9 @@ package seedu.address.model;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 
-import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.util.Pair;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.ObservableObject;
 import seedu.address.model.commission.Commission;
@@ -96,7 +96,7 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public ObservableValue<FilteredList<Commission>> getObservableFilteredCommissionList() {
+    public ObservableObject<Pair<Customer, FilteredList<Commission>>> getObservableFilteredCommissionList() {
         throw new AssertionError("This method should not be called.");
     }
 

--- a/src/test/java/seedu/address/model/customer/CustomerTest.java
+++ b/src/test/java/seedu/address/model/customer/CustomerTest.java
@@ -65,8 +65,9 @@ public class CustomerTest {
 
     @Test
     public void equals() {
+        Customer alice = new CustomerBuilder(ALICE).build();
         // same values -> returns true
-        Customer aliceCopy = new CustomerBuilder(ALICE).build();
+        Customer aliceCopy = new CustomerBuilder(alice).build();
         assertTrue(ALICE.equals(aliceCopy));
 
         // same object -> returns true


### PR DESCRIPTION
Wrap observableCommissionsList in a Pair with customer
- There is an issue where two identical UniqueCommissionLists for different customers would have the same hash and switching between customers with identical lists would not trigger the change listener for the observableFilteredCommissions.

Avoid deselecting the current item if it is not modified by the previous command