### PR TITLE
Implement sort functionality for customers

### DIFF
--- a/docs/diagrams/DeleteSequenceDiagram.puml
+++ b/docs/diagrams/DeleteSequenceDiagram.puml
@@ -49,7 +49,7 @@ deactivate AddressBookParser
 LogicManager -> DeleteCustomerCommand : execute()
 activate DeleteCustomerCommand
 
-DeleteCustomerCommand -> Model : getFilteredCustomerList()
+DeleteCustomerCommand -> Model : getSortedFilteredCustomerList()
 activate Model
 
 Model --> DeleteCustomerCommand : customerList

--- a/docs/tutorials/AddRemark.md
+++ b/docs/tutorials/AddRemark.md
@@ -337,7 +337,7 @@ save it with `Model#setCustomer()`.
 //...
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        List<Customer> lastShownList = model.getFilteredCustomerList();
+        List<Customer> lastShownList = model.getSortedFilteredCustomerList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CUSTOMER_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -11,6 +11,10 @@ public class Messages {
     public static final String MESSAGE_CUSTOMERS_LISTED_OVERVIEW = "%1$d customers listed!";
     public static final String MESSAGE_NO_ACTIVE_CUSTOMER = "This command requires you to open a customer first!";
 
+    public static final String MESSAGE_CUSTOMERS_SORTED = "%1$d customers sorted in %2$s order by %3$s!";
+
+    public static final String MESSAGE_INVALID_UNIQUE_COMPARATOR = "The sort command requires exactly one option.";
+
     /* Commission Messages */
     public static final String MESSAGE_INVALID_COMMISSION_DISPLAYED_INDEX = "The commission index provided is invalid";
     public static final String MESSAGE_NO_ACTIVE_COMMISSION = "This command requires you to open a commission first!";

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -35,8 +35,8 @@ public interface Logic {
      */
     ReadOnlyAddressBook getAddressBook();
 
-    /** Returns an unmodifiable view of the filtered list of customers */
-    ObservableList<Customer> getFilteredCustomerList();
+    /** Returns an unmodifiable view of the sorted and filtered list of customers */
+    ObservableList<Customer> getSortedFilteredCustomerList();
 
     /**
      * Returns an unmodifiable view of the filtered list of commission

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -2,9 +2,9 @@ package seedu.address.logic;
 
 import java.nio.file.Path;
 
-import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.util.Pair;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.ObservableObject;
 import seedu.address.logic.commands.CommandResult;
@@ -38,8 +38,10 @@ public interface Logic {
     /** Returns an unmodifiable view of the filtered list of customers */
     ObservableList<Customer> getFilteredCustomerList();
 
-    /** Returns an unmodifiable view of the filtered list of commission */
-    ObservableValue<FilteredList<Commission>> getObservableFilteredCommissionList();
+    /**
+     * Returns an unmodifiable view of the filtered list of commission
+     */
+    ObservableObject<Pair<Customer, FilteredList<Commission>>> getObservableFilteredCommissionList();
     /**
      * Returns the user prefs' address book file path.
      */

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -71,8 +71,8 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public ObservableList<Customer> getFilteredCustomerList() {
-        return model.getFilteredCustomerList();
+    public ObservableList<Customer> getSortedFilteredCustomerList() {
+        return model.getSortedFilteredCustomerList();
     }
 
 
@@ -118,9 +118,9 @@ public class LogicManager implements Logic {
 
     @Override
     public void selectValidCustomer() {
-        if (!model.getFilteredCustomerList().contains(model.getSelectedCustomer().getValue())) {
+        if (!model.getSortedFilteredCustomerList().contains(model.getSelectedCustomer().getValue())) {
             model.updateFilteredCustomerList(PREDICATE_SHOW_ALL_CUSTOMERS);
-            List<Customer> customers = model.getFilteredCustomerList();
+            List<Customer> customers = model.getSortedFilteredCustomerList();
             model.selectCustomer(customers.size() > 0 ? customers.get(0) : null);
         }
     }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -8,9 +8,9 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.logging.Logger;
 
-import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.util.Pair;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.ObservableObject;
@@ -77,7 +77,7 @@ public class LogicManager implements Logic {
 
 
     @Override
-    public ObservableValue<FilteredList<Commission>> getObservableFilteredCommissionList() {
+    public ObservableObject<Pair<Customer, FilteredList<Commission>>> getObservableFilteredCommissionList() {
         return model.getObservableFilteredCommissionList();
     }
 
@@ -127,9 +127,12 @@ public class LogicManager implements Logic {
 
     @Override
     public void selectValidCommission() {
-        if (!model.getFilteredCommissionList().contains(model.getSelectedCommission().getValue())) {
+        FilteredList<Commission> commissions = model.getFilteredCommissionList();
+        if (commissions == null) {
+            model.selectCommission(null);
+        } else if (!commissions.contains(model.getSelectedCommission().getValue())) {
             model.updateFilteredCommissionList(PREDICATE_SHOW_ALL_COMMISSIONS);
-            List<Commission> commissions = model.getFilteredCommissionList();
+            commissions = model.getObservableFilteredCommissionList().getValue().getValue();
             model.selectCommission(commissions.size() > 0 ? commissions.get(0) : null);
         }
     }

--- a/src/main/java/seedu/address/logic/commands/AddCommissionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommissionCommand.java
@@ -65,8 +65,8 @@ public class AddCommissionCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_COMMISSION);
         }
         selectedCustomer.addCommission(newCommission);
-
         model.selectTab(GuiTab.COMMISSION);
+        model.selectCommission(newCommission);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddCustomerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCustomerCommand.java
@@ -58,6 +58,7 @@ public class AddCustomerCommand extends Command {
 
         model.addCustomer(toAdd);
         model.selectTab(GuiTab.CUSTOMER);
+        model.selectCustomer(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommissionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommissionCommand.java
@@ -46,12 +46,17 @@ public class DeleteCommissionCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_COMMISSION_DISPLAYED_INDEX);
         }
 
+        Commission selectedCommission = model.getSelectedCommission().getValue();
         Commission commissionToDelete = lastShownList.get(targetIndex.getZeroBased());
         Customer customer = commissionToDelete.getCustomer();
         customer.removeCommission(commissionToDelete);
-        model.updateFilteredCommissionList(PREDICATE_SHOW_ALL_COMMISSIONS);
         model.selectTab(GuiTab.COMMISSION);
-        model.selectCommission(null);
+        model.updateFilteredCommissionList(PREDICATE_SHOW_ALL_COMMISSIONS);
+        if (selectedCommission != null && !selectedCommission.isSameCommission(commissionToDelete)) {
+            model.selectCommission(selectedCommission);
+        } else {
+            model.selectCommission(null);
+        }
 
         return new CommandResult(String.format(MESSAGE_DELETE_COMMISSION_SUCCESS, commissionToDelete));
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteCustomerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCustomerCommand.java
@@ -42,11 +42,15 @@ public class DeleteCustomerCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_CUSTOMER_DISPLAYED_INDEX);
         }
 
+        model.selectTab(GuiTab.CUSTOMER);
+        Customer selectedCustomer = model.getSelectedCustomer().getValue();
         Customer customerToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteCustomer(customerToDelete);
+        if (!selectedCustomer.isSameCustomer(customerToDelete)) {
+            model.selectCustomer(selectedCustomer);
+        }
 
         model.updateFilteredCustomerList(PREDICATE_SHOW_ALL_CUSTOMERS);
-        model.selectTab(GuiTab.CUSTOMER);
         return new CommandResult(String.format(MESSAGE_DELETE_CUSTOMER_SUCCESS, customerToDelete));
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCustomerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCustomerCommand.java
@@ -36,7 +36,7 @@ public class DeleteCustomerCommand extends Command {
     @Override
     public CommandResult execute(Model model, Storage...storage) throws CommandException {
         requireNonNull(model);
-        List<Customer> lastShownList = model.getFilteredCustomerList();
+        List<Customer> lastShownList = model.getSortedFilteredCustomerList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CUSTOMER_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -93,7 +93,7 @@ public class EditCommand extends Command {
     @Override
     public CommandResult execute(Model model, Storage...storage) throws CommandException {
         requireNonNull(model);
-        List<Customer> lastShownList = model.getFilteredCustomerList();
+        List<Customer> lastShownList = model.getSortedFilteredCustomerList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CUSTOMER_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -33,7 +33,8 @@ public class FindCommand extends Command {
         model.updateFilteredCustomerList(predicate);
         model.selectTab(GuiTab.CUSTOMER);
         return new CommandResult(
-                String.format(Messages.MESSAGE_CUSTOMERS_LISTED_OVERVIEW, model.getFilteredCustomerList().size()));
+                String.format(Messages.MESSAGE_CUSTOMERS_LISTED_OVERVIEW,
+                        model.getSortedFilteredCustomerList().size()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/OpenCustomerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/OpenCustomerCommand.java
@@ -36,7 +36,7 @@ public class OpenCustomerCommand extends Command {
     public CommandResult execute(Model model, Storage...storage) throws CommandException {
         requireNonNull(model);
 
-        List<Customer> lastShownList = model.getFilteredCustomerList();
+        List<Customer> lastShownList = model.getSortedFilteredCustomerList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CUSTOMER_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/SortCustomerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCustomerCommand.java
@@ -1,0 +1,66 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_CUSTOMER_COMMISSION_COUNT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_CUSTOMER_NAME;
+
+import java.util.Comparator;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.customer.Customer;
+import seedu.address.model.util.SortDirection;
+import seedu.address.storage.Storage;
+import seedu.address.ui.GuiTab;
+
+/**
+ * Sorts the customers in address book by the specified comparator.
+ */
+public class SortCustomerCommand extends Command {
+
+    public static final String COMMAND_WORD = "sortcus";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts the displayed customer list by one of the "
+            + "following options: \n"
+            + "Prefix:"
+            + "\t" + PREFIX_SORT_CUSTOMER_NAME + ": the customer's name, "
+            + "\t" + PREFIX_SORT_CUSTOMER_COMMISSION_COUNT + ": the number of commissions\n"
+            + "Suffix: + (increasing) or - (decreasing)\n"
+            + "Parameters: [n/(+/-)] [c/(+/-)] \n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_SORT_CUSTOMER_NAME + "+"
+            + " sorts the list in increasing order by name";
+
+    private final Comparator<Customer> comparator;
+    private final String comparatorDescription;
+    private final SortDirection direction;
+
+    /**
+     * @param comparator comparator to use to sort the customer list
+     * @param comparatorDescription description of the comparator
+     * @param direction direction of the comparator
+     */
+    public SortCustomerCommand(Comparator<Customer> comparator, String comparatorDescription, SortDirection direction) {
+        this.comparator = comparator;
+        this.comparatorDescription = comparatorDescription;
+        this.direction = direction;
+    }
+
+    @Override
+    public CommandResult execute(Model model, Storage...storage) {
+        requireNonNull(model);
+        model.updateSortedCustomerList(comparator);
+        model.selectTab(GuiTab.CUSTOMER);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_CUSTOMERS_SORTED,
+                        model.getSortedFilteredCustomerList().size(),
+                        direction.toString(),
+                        comparatorDescription));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof SortCustomerCommand // instanceof handles nulls
+                && comparator.equals(((SortCustomerCommand) other).comparator)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/SortCustomerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCustomerCommand.java
@@ -1,12 +1,13 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_CUSTOMER_COMMISSION_COUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_CUSTOMER_NAME;
 
 import java.util.Comparator;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.core.Messages;
+import seedu.address.logic.parser.SortCustomerCommandParser;
 import seedu.address.model.Model;
 import seedu.address.model.customer.Customer;
 import seedu.address.model.util.SortDirection;
@@ -20,11 +21,15 @@ public class SortCustomerCommand extends Command {
 
     public static final String COMMAND_WORD = "sortcus";
 
+    public static final String PREFIXES = SortCustomerCommandParser.PREFIX_DESCRIPTION_MAP.entrySet().stream()
+            .map(prefixPairEntry -> prefixPairEntry.getKey() + "(" + prefixPairEntry.getValue().getKey() + ")")
+            .collect(Collectors.joining("   "));
+
+
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts the displayed customer list by one of the "
             + "following options: \n"
-            + "Prefix:"
-            + "\t" + PREFIX_SORT_CUSTOMER_NAME + ": the customer's name, "
-            + "\t" + PREFIX_SORT_CUSTOMER_COMMISSION_COUNT + ": the number of commissions\n"
+            + "Prefix: "
+            + PREFIXES + "\n"
             + "Suffix: + (increasing) or - (decreasing)\n"
             + "Parameters: [n/(+/-)] [c/(+/-)] \n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_SORT_CUSTOMER_NAME + "+"

--- a/src/main/java/seedu/address/logic/parser/AddCommissionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommissionCommandParser.java
@@ -7,10 +7,10 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_FEE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
+import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
 
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommissionCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -26,14 +26,6 @@ import seedu.address.model.tag.Tag;
  * Parses input arguments and creates a new AddCommissionCommand object.
  */
 public class AddCommissionCommandParser implements Parser<AddCommissionCommand> {
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
      * and returns an AddCommand object for execution.

--- a/src/main/java/seedu/address/logic/parser/AddCustomerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCustomerCommandParser.java
@@ -6,10 +6,10 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
 
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCustomerCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -24,15 +24,6 @@ import seedu.address.model.tag.Tag;
  * Parses input arguments and creates a new AddCustomerCommand object.
  */
 public class AddCustomerCommandParser implements Parser<AddCustomerCommand> {
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
     /**
      * Parses the given {@code String} of arguments in the context of the AddCustomerCommand
      * and returns an AddCustomerCommand object for execution.
@@ -44,7 +35,7 @@ public class AddCustomerCommandParser implements Parser<AddCustomerCommand> {
             ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL)
-            || !argMultimap.getPreamble().isEmpty()) {
+                || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCustomerCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.OpenCommissionCommand;
 import seedu.address.logic.commands.OpenCustomerCommand;
+import seedu.address.logic.commands.SortCustomerCommand;
 import seedu.address.logic.commands.iteration.AddIterationCommand;
 import seedu.address.logic.commands.iteration.DeleteIterationCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -93,6 +94,9 @@ public class AddressBookParser {
 
         case DeleteCommissionCommand.COMMAND_WORD:
             return new DeleteCommissionCommandParser().parse(arguments);
+
+        case SortCustomerCommand.COMMAND_WORD:
+            return new SortCustomerCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -27,5 +27,7 @@ public class CliSyntax {
 
     /* Sorting Prefixes */
     public static final Prefix PREFIX_SORT_CUSTOMER_NAME = new Prefix("n/");
+    public static final Prefix PREFIX_SORT_CUSTOMER_ACTIVE_COMMISSION_COUNT = new Prefix("a/");
     public static final Prefix PREFIX_SORT_CUSTOMER_COMMISSION_COUNT = new Prefix("c/");
+    public static final Prefix PREFIX_SORT_CUSTOMER_REVENUE = new Prefix("r/");
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -24,4 +24,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_ITERATION_DESCRIPTION = new Prefix("n/");
     public static final Prefix PREFIX_ITERATION_IMAGEPATH = new Prefix("p/");
     public static final Prefix PREFIX_ITERATION_FEEDBACK = new Prefix("f/");
+
+    /* Sorting Prefixes */
+    public static final Prefix PREFIX_SORT_CUSTOMER_NAME = new Prefix("n/");
+    public static final Prefix PREFIX_SORT_CUSTOMER_COMMISSION_COUNT = new Prefix("c/");
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -30,4 +30,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_SORT_CUSTOMER_ACTIVE_COMMISSION_COUNT = new Prefix("a/");
     public static final Prefix PREFIX_SORT_CUSTOMER_COMMISSION_COUNT = new Prefix("c/");
     public static final Prefix PREFIX_SORT_CUSTOMER_REVENUE = new Prefix("r/");
+    public static final Prefix PREFIX_SORT_CUSTOMER_LAST_DATE = new Prefix("d/");
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -10,6 +10,7 @@ import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -29,6 +30,7 @@ import seedu.address.model.iteration.Feedback;
 import seedu.address.model.iteration.ImagePath;
 import seedu.address.model.iteration.IterationDescription;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.util.SortDirection;
 
 /**
  * Contains utility methods used for parsing strings in the various *Parser classes.
@@ -268,9 +270,46 @@ public class ParserUtil {
      * Parses a {@code String feedback} into a {@code Feedback}.
      * Leading and trailing whitespaces will be trimmed.
      */
-    public static Feedback parseFeedback(String feedback) throws ParseException {
+    public static Feedback parseFeedback(String feedback) {
         requireNonNull(feedback);
         String trimmedFeedback = feedback.trim();
         return new Feedback(trimmedFeedback);
+    }
+
+    /**
+     * Parses a {@code String sort direction} into a {@code SortDirection}.
+     * Leading and trailing whitespaces will be trimmed.
+     */
+    public static SortDirection parseSortDirection(String direction) throws ParseException {
+        requireNonNull(direction);
+        String trimmedDirection = direction.trim();
+        if (!SortDirection.isValidSortDirection(trimmedDirection)) {
+            throw new ParseException(SortDirection.MESSAGE_CONSTRAINTS);
+        }
+        return new SortDirection(trimmedDirection);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    public static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    /**
+     * Returns true if not all the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    public static boolean areAnyPrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+
+    /**
+     * Returns count of prefixes present in the given {@code ArgumentMultimap}.
+     */
+    public static long countPrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).filter(prefix -> argumentMultimap.getValue(prefix).isPresent()).count();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SortCustomerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCustomerCommandParser.java
@@ -3,13 +3,17 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_UNIQUE_COMPARATOR;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_CUSTOMER_ACTIVE_COMMISSION_COUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_CUSTOMER_COMMISSION_COUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_CUSTOMER_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_CUSTOMER_REVENUE;
 import static seedu.address.logic.parser.ParserUtil.areAnyPrefixesPresent;
 import static seedu.address.logic.parser.ParserUtil.countPrefixesPresent;
 import static seedu.address.logic.parser.ParserUtil.parseSortDirection;
 import static seedu.address.model.Model.CUSTOMER_NAME_COMPARATOR;
+import static seedu.address.model.Model.CUSTOMER_NUM_ACTIVE_COMMISSIONS_COMPARATOR;
 import static seedu.address.model.Model.CUSTOMER_NUM_COMMISSIONS_COMPARATOR;
+import static seedu.address.model.Model.CUSTOMER_REVENUE_COMPARATOR;
 
 import java.util.Comparator;
 import java.util.HashMap;
@@ -34,6 +38,10 @@ public class SortCustomerCommandParser implements Parser<SortCustomerCommand> {
         PREFIX_DESCRIPTION_MAP.put(PREFIX_SORT_CUSTOMER_NAME, new Pair<>("name", CUSTOMER_NAME_COMPARATOR));
         PREFIX_DESCRIPTION_MAP.put(PREFIX_SORT_CUSTOMER_COMMISSION_COUNT,
                 new Pair<>("commission count", CUSTOMER_NUM_COMMISSIONS_COMPARATOR));
+        PREFIX_DESCRIPTION_MAP.put(PREFIX_SORT_CUSTOMER_ACTIVE_COMMISSION_COUNT,
+                new Pair<>("active commissions count", CUSTOMER_NUM_ACTIVE_COMMISSIONS_COMPARATOR));
+        PREFIX_DESCRIPTION_MAP.put(PREFIX_SORT_CUSTOMER_REVENUE,
+                new Pair<>("revenue", CUSTOMER_REVENUE_COMPARATOR));
     }
 
     /**
@@ -43,15 +51,16 @@ public class SortCustomerCommandParser implements Parser<SortCustomerCommand> {
      */
     public SortCustomerCommand parse(String args) throws ParseException {
         requireNonNull(args);
+        Prefix[] allPrefixes = PREFIX_DESCRIPTION_MAP.keySet().toArray(new Prefix[0]);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_SORT_CUSTOMER_NAME, PREFIX_SORT_CUSTOMER_COMMISSION_COUNT);
-        if (!areAnyPrefixesPresent(argMultimap, PREFIX_SORT_CUSTOMER_NAME, PREFIX_SORT_CUSTOMER_COMMISSION_COUNT)
+                ArgumentTokenizer.tokenize(args, allPrefixes);
+        if (!areAnyPrefixesPresent(argMultimap, allPrefixes)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCustomerCommand.MESSAGE_USAGE));
         }
 
 
-        if (countPrefixesPresent(argMultimap, PREFIX_SORT_CUSTOMER_NAME, PREFIX_SORT_CUSTOMER_COMMISSION_COUNT) != 1) {
+        if (countPrefixesPresent(argMultimap, allPrefixes) != 1) {
             throw new ParseException(MESSAGE_INVALID_UNIQUE_COMPARATOR);
         }
         Comparator<Customer> comparator = (c1, c2) -> 0;

--- a/src/main/java/seedu/address/logic/parser/SortCustomerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCustomerCommandParser.java
@@ -64,10 +64,8 @@ public class SortCustomerCommandParser implements Parser<SortCustomerCommand> {
     public SortCustomerCommand parse(String args) throws ParseException {
         requireNonNull(args);
         Prefix[] allPrefixes = PREFIX_DESCRIPTION_MAP.keySet().toArray(new Prefix[0]);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, allPrefixes);
-        if (!areAnyPrefixesPresent(argMultimap, allPrefixes)
-                || !argMultimap.getPreamble().isEmpty()) {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, allPrefixes);
+        if (!areAnyPrefixesPresent(argMultimap, allPrefixes) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCustomerCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/seedu/address/logic/parser/SortCustomerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCustomerCommandParser.java
@@ -1,0 +1,77 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_UNIQUE_COMPARATOR;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_CUSTOMER_COMMISSION_COUNT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_CUSTOMER_NAME;
+import static seedu.address.logic.parser.ParserUtil.areAnyPrefixesPresent;
+import static seedu.address.logic.parser.ParserUtil.countPrefixesPresent;
+import static seedu.address.logic.parser.ParserUtil.parseSortDirection;
+import static seedu.address.model.Model.CUSTOMER_NAME_COMPARATOR;
+import static seedu.address.model.Model.CUSTOMER_NUM_COMMISSIONS_COMPARATOR;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import javafx.util.Pair;
+import seedu.address.logic.commands.SortCustomerCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.customer.Customer;
+import seedu.address.model.util.SortDirection;
+
+/**
+ * Parses input arguments and creates a new FindCommand object
+ */
+public class SortCustomerCommandParser implements Parser<SortCustomerCommand> {
+
+    public static final Map<Prefix, Pair<String, Comparator<Customer>>> PREFIX_DESCRIPTION_MAP;
+
+    static {
+        PREFIX_DESCRIPTION_MAP = new HashMap<>();
+        PREFIX_DESCRIPTION_MAP.put(PREFIX_SORT_CUSTOMER_NAME, new Pair<>("name", CUSTOMER_NAME_COMPARATOR));
+        PREFIX_DESCRIPTION_MAP.put(PREFIX_SORT_CUSTOMER_COMMISSION_COUNT,
+                new Pair<>("commission count", CUSTOMER_NUM_COMMISSIONS_COMPARATOR));
+    }
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindCommand
+     * and returns a FindCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public SortCustomerCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_SORT_CUSTOMER_NAME, PREFIX_SORT_CUSTOMER_COMMISSION_COUNT);
+        if (!areAnyPrefixesPresent(argMultimap, PREFIX_SORT_CUSTOMER_NAME, PREFIX_SORT_CUSTOMER_COMMISSION_COUNT)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCustomerCommand.MESSAGE_USAGE));
+        }
+
+
+        if (countPrefixesPresent(argMultimap, PREFIX_SORT_CUSTOMER_NAME, PREFIX_SORT_CUSTOMER_COMMISSION_COUNT) != 1) {
+            throw new ParseException(MESSAGE_INVALID_UNIQUE_COMPARATOR);
+        }
+        Comparator<Customer> comparator = (c1, c2) -> 0;
+        String comparatorDescription = "";
+        SortDirection direction = new SortDirection("+");
+        for (Prefix key: PREFIX_DESCRIPTION_MAP.keySet()) {
+            Optional<String> suffix = argMultimap.getValue(key);
+            if (suffix.isEmpty()) {
+                continue;
+            }
+            Pair<String, Comparator<Customer>> comparatorEntry = PREFIX_DESCRIPTION_MAP.get(key);
+            comparatorDescription = comparatorEntry.getKey();
+            comparator = comparatorEntry.getValue();
+            direction = parseSortDirection(suffix.get());
+            if (!direction.isIncreasing()) {
+                comparator = comparator.reversed();
+            }
+            break;
+        }
+        return new SortCustomerCommand(comparator, comparatorDescription, direction);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/SortCustomerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCustomerCommandParser.java
@@ -5,11 +5,13 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_UNIQUE_COMPARATOR;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_CUSTOMER_ACTIVE_COMMISSION_COUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_CUSTOMER_COMMISSION_COUNT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_CUSTOMER_LAST_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_CUSTOMER_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_CUSTOMER_REVENUE;
 import static seedu.address.logic.parser.ParserUtil.areAnyPrefixesPresent;
 import static seedu.address.logic.parser.ParserUtil.countPrefixesPresent;
 import static seedu.address.logic.parser.ParserUtil.parseSortDirection;
+import static seedu.address.model.Model.CUSTOMER_LAST_DATE_COMPARATOR;
 import static seedu.address.model.Model.CUSTOMER_NAME_COMPARATOR;
 import static seedu.address.model.Model.CUSTOMER_NUM_ACTIVE_COMMISSIONS_COMPARATOR;
 import static seedu.address.model.Model.CUSTOMER_NUM_COMMISSIONS_COMPARATOR;
@@ -42,6 +44,8 @@ public class SortCustomerCommandParser implements Parser<SortCustomerCommand> {
                 new Pair<>("active commissions count", CUSTOMER_NUM_ACTIVE_COMMISSIONS_COMPARATOR));
         PREFIX_DESCRIPTION_MAP.put(PREFIX_SORT_CUSTOMER_REVENUE,
                 new Pair<>("revenue", CUSTOMER_REVENUE_COMPARATOR));
+        PREFIX_DESCRIPTION_MAP.put(PREFIX_SORT_CUSTOMER_LAST_DATE,
+                new Pair<>("latest commission date", CUSTOMER_LAST_DATE_COMPARATOR));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/iteration/AddIterationCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/iteration/AddIterationCommandParser.java
@@ -5,15 +5,13 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ITERATION_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ITERATION_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ITERATION_FEEDBACK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ITERATION_IMAGEPATH;
-
-import java.util.stream.Stream;
+import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
 
 import seedu.address.logic.commands.iteration.AddIterationCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
-import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.iteration.Date;
 import seedu.address.model.iteration.Feedback;
@@ -25,15 +23,6 @@ import seedu.address.model.iteration.IterationDescription;
  * Parses input arguments and creates a new AddIterationCommand object.
  */
 public class AddIterationCommandParser implements Parser<AddIterationCommand> {
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
     /**
      * Parses the given {@code String} of arguments in the context of the AddIterationCommand
      * and returns an AddIteration object for execution.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -37,6 +37,17 @@ public interface Model {
      */
     Comparator<Customer> CUSTOMER_NUM_COMMISSIONS_COMPARATOR = Comparator.comparing(Customer::getCommissionsCount);
 
+    /**
+     * {@code Comparator} that sorts by number of active commissions
+     */
+    Comparator<Customer> CUSTOMER_NUM_ACTIVE_COMMISSIONS_COMPARATOR =
+            Comparator.comparing(Customer::getActiveCommissionCount);
+
+    /**
+     * {@code Comparator} that sorts by customer's revenue
+     */
+    Comparator<Customer> CUSTOMER_REVENUE_COMPARATOR = Comparator.comparing(Customer::getRevenue);
+
 
     /**
      * Returns the user prefs.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -3,9 +3,9 @@ package seedu.address.model;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 
-import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.util.Pair;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.ObservableObject;
 import seedu.address.model.commission.Commission;
@@ -112,12 +112,12 @@ public interface Model {
      * Returns an unmodifiable view of the list of {@code Commission} backed by the internal list of
      * {@code versionedAddressBook}
      */
-    ObservableList<Commission> getFilteredCommissionList();
+    FilteredList<Commission> getFilteredCommissionList();
 
     /**
      * Returns an observable instance of the current filtered list of {@code Commission}
      */
-    ObservableValue<FilteredList<Commission>> getObservableFilteredCommissionList();
+    ObservableObject<Pair<Customer, FilteredList<Commission>>> getObservableFilteredCommissionList();
 
     /**
      * Updates the filter of the current filtered commission list to filter by the given {@code predicate}.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -25,6 +26,17 @@ public interface Model {
      * {@code Predicate} that always evaluate to true
      */
     Predicate<Commission> PREDICATE_SHOW_ALL_COMMISSIONS = unused -> true;
+
+    /**
+     * {@code Comparator} that sorts by name
+     */
+    Comparator<Customer> CUSTOMER_NAME_COMPARATOR = Comparator.comparing(Customer::getName);
+
+    /**
+     * {@code Comparator} that sorts by number of commissions
+     */
+    Comparator<Customer> CUSTOMER_NUM_COMMISSIONS_COMPARATOR = Comparator.comparing(Customer::getCommissionsCount);
+
 
     /**
      * Returns the user prefs.
@@ -95,9 +107,9 @@ public interface Model {
     void selectCustomer(Customer customer);
 
     /**
-     * Returns an unmodifiable view of the filtered customer list
+     * Returns an unmodifiable view of the sorted and filtered customer list
      */
-    ObservableList<Customer> getFilteredCustomerList();
+    ObservableList<Customer> getSortedFilteredCustomerList();
 
     /**
      * Updates the filter of the filtered customer list to filter by the given {@code predicate}.
@@ -107,6 +119,12 @@ public interface Model {
 
     void updateFilteredCustomerList(Predicate<Customer> predicate);
 
+    /**
+     * Updates the comparator of the sorted customer list to sort by the given {@code comparator}.
+     *
+     * @throws NullPointerException if {@code comparator} is null.
+     */
+    void updateSortedCustomerList(Comparator<Customer> comparator);
 
     /**
      * Returns an unmodifiable view of the list of {@code Commission} backed by the internal list of

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -48,6 +48,12 @@ public interface Model {
      */
     Comparator<Customer> CUSTOMER_REVENUE_COMPARATOR = Comparator.comparing(Customer::getRevenue);
 
+    /**
+     * {@code Comparator} that sorts by the customer's latest commission
+     */
+    Comparator<Customer> CUSTOMER_LAST_DATE_COMPARATOR = Comparator.comparing(Customer::getLastDate);
+
+
 
     /**
      * Returns the user prefs.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -185,7 +185,7 @@ public class ModelManager implements Model {
         if (filteredCustomers.size() == 0) {
             selectCustomer(null);
         } else if (hasSelectedCustomer() && filteredCustomers.stream()
-                    .noneMatch(selectedCustomer.getValue()::isSameCustomer)) {
+                .noneMatch(selectedCustomer.getValue()::isSameCustomer)) {
             selectCustomer(filteredCustomers.get(0));
         }
     }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,12 +4,14 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
 import javafx.util.Pair;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
@@ -27,6 +29,7 @@ public class ModelManager implements Model {
 
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
+    private final SortedList<Customer> sortedFilteredCustomers;
     private final FilteredList<Customer> filteredCustomers;
     private final ObservableObject<Pair<Customer, FilteredList<Commission>>> observableFilteredCommissions =
             new ObservableObject<>();
@@ -49,6 +52,8 @@ public class ModelManager implements Model {
         this.userPrefs = new UserPrefs(userPrefs);
 
         filteredCustomers = new FilteredList<>(this.addressBook.getCustomerList());
+        sortedFilteredCustomers = new SortedList<>(filteredCustomers);
+        sortedFilteredCustomers.setComparator(CUSTOMER_NAME_COMPARATOR);
 
         setSelectedCustomerCommissions(null);
 
@@ -174,8 +179,8 @@ public class ModelManager implements Model {
      * {@code versionedAddressBook}
      */
     @Override
-    public ObservableList<Customer> getFilteredCustomerList() {
-        return filteredCustomers;
+    public ObservableList<Customer> getSortedFilteredCustomerList() {
+        return sortedFilteredCustomers;
     }
 
     @Override
@@ -188,6 +193,12 @@ public class ModelManager implements Model {
                 .noneMatch(selectedCustomer.getValue()::isSameCustomer)) {
             selectCustomer(filteredCustomers.get(0));
         }
+    }
+
+    @Override
+    public void updateSortedCustomerList(Comparator<Customer> comparator) {
+        requireNonNull(comparator);
+        sortedFilteredCustomers.setComparator(comparator);
     }
 
     //=========== Filtered Commission List Accessors =============================================================

--- a/src/main/java/seedu/address/model/commission/UniqueCommissionList.java
+++ b/src/main/java/seedu/address/model/commission/UniqueCommissionList.java
@@ -111,6 +111,11 @@ public class UniqueCommissionList implements Iterable<Commission> {
         return internalList.iterator();
     }
 
+    /** Returns size of the commission list. */
+    public int size() {
+        return internalList.size();
+    }
+
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object

--- a/src/main/java/seedu/address/model/commission/UniqueCommissionList.java
+++ b/src/main/java/seedu/address/model/commission/UniqueCommissionList.java
@@ -145,11 +145,6 @@ public class UniqueCommissionList implements Iterable<Commission> {
         return internalList.iterator();
     }
 
-    /** Returns size of the commission list. */
-    public int size() {
-        return internalList.size();
-    }
-
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object

--- a/src/main/java/seedu/address/model/customer/Customer.java
+++ b/src/main/java/seedu/address/model/customer/Customer.java
@@ -71,6 +71,10 @@ public class Customer {
         return commissions.asUnmodifiableObservableList();
     }
 
+    public int getCommissionsCount() {
+        return commissions.size();
+    }
+
     /**
      * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
      * if modification is attempted.

--- a/src/main/java/seedu/address/model/customer/Customer.java
+++ b/src/main/java/seedu/address/model/customer/Customer.java
@@ -105,7 +105,7 @@ public class Customer {
     }
 
     public int getCommissionsCount() {
-        return commissions.size();
+        return commissions.getSize();
     }
 
     /**

--- a/src/main/java/seedu/address/model/customer/Name.java
+++ b/src/main/java/seedu/address/model/customer/Name.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Customer's name in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
  */
-public class Name {
+public class Name implements Comparable<Name> {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
@@ -56,4 +56,9 @@ public class Name {
         return fullName.hashCode();
     }
 
+    @Override
+    public int compareTo(Name name) {
+        requireNonNull(name);
+        return fullName.compareTo(name.fullName);
+    }
 }

--- a/src/main/java/seedu/address/model/util/SortDirection.java
+++ b/src/main/java/seedu/address/model/util/SortDirection.java
@@ -1,0 +1,56 @@
+package seedu.address.model.util;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a direction for the sort command.
+ * Guarantees: immutable; is valid as declared in {@link #isValidSortDirection(String)} (String)}
+ */
+public class SortDirection {
+
+
+    public static final String MESSAGE_CONSTRAINTS =
+        "Sort direction should be one of '+' or '-'";
+    public static final String VALIDATION_REGEX = "[+-]";
+    public final Boolean isIncreasing;
+
+    /**
+     * Constructs a {@code SortDirection} from the user input.
+     *
+     * @param direction A valid direction (+/-).
+     */
+    public SortDirection(String direction) {
+        requireNonNull(direction);
+        checkArgument(isValidSortDirection(direction), MESSAGE_CONSTRAINTS);
+        isIncreasing = direction.strip().compareTo("+") == 0;
+    }
+
+    /**
+     * Returns true if a given string is a valid phone number.
+     */
+    public static boolean isValidSortDirection(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return isIncreasing ? "increasing" : "decreasing";
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof SortDirection // instanceof handles nulls
+            && isIncreasing.equals(((SortDirection) other).isIncreasing)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return isIncreasing.hashCode();
+    }
+
+    public boolean isIncreasing() {
+        return isIncreasing;
+    }
+}

--- a/src/main/java/seedu/address/model/util/SortDirection.java
+++ b/src/main/java/seedu/address/model/util/SortDirection.java
@@ -8,6 +8,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; is valid as declared in {@link #isValidSortDirection(String)} (String)}
  */
 public class SortDirection {
+    public static final SortDirection INCREASING = new SortDirection("+");
+    public static final SortDirection DECREASING = new SortDirection("-");
 
 
     public static final String MESSAGE_CONSTRAINTS =

--- a/src/main/java/seedu/address/storage/JsonAdaptedCustomer.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedCustomer.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.commission.UniqueCommissionList;
 import seedu.address.model.customer.Address;
 import seedu.address.model.customer.Customer;
 import seedu.address.model.customer.Email;
@@ -128,9 +127,8 @@ class JsonAdaptedCustomer {
 
 
         final Set<Tag> modelTags = new HashSet<>(customerTags);
-        final UniqueCommissionList customerCommissions = new UniqueCommissionList();
         Customer.CustomerBuilder customerBuilder = new Customer.CustomerBuilder(modelName, modelPhone, modelEmail,
-                modelTags).setCommissions(customerCommissions);
+                modelTags);
         modelAddress.ifPresent(customerBuilder::setAddress);
         Customer customer = customerBuilder.build();
 

--- a/src/main/java/seedu/address/ui/CommissionListPanel.java
+++ b/src/main/java/seedu/address/ui/CommissionListPanel.java
@@ -3,16 +3,17 @@ package seedu.address.ui;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 
-import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
+import javafx.util.Pair;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.ObservableObject;
 import seedu.address.model.commission.Commission;
+import seedu.address.model.customer.Customer;
 
 /**
  * Panel containing the list of commissions.
@@ -28,14 +29,14 @@ public class CommissionListPanel extends UiPart<Region> {
     /**
      * Creates a {@code CommissionListPanel} with the given {@code ObservableList}.
      */
-    public CommissionListPanel(ObservableValue<FilteredList<Commission>> observableCommissionList,
+    public CommissionListPanel(ObservableObject<Pair<Customer, FilteredList<Commission>>> observableCommissionList,
                                Consumer<Commission> selectCommission,
                                ObservableObject<Commission> selectedCommission) {
         super(FXML);
-        this.updateUI(observableCommissionList.getValue());
+        this.updateUI(observableCommissionList.getValue().getValue());
         this.selectCommission = selectCommission;
 
-        observableCommissionList.addListener((observable, oldValue, newValue) -> this.updateUI(newValue));
+        observableCommissionList.addListener((observable, oldValue, newValue) -> this.updateUI(newValue.getValue()));
         commissionListView.getSelectionModel().select(selectedCommission.getValue());
         selectedCommission.addListener(((observable, oldValue, newValue) ->
                 commissionListView.getSelectionModel().select(newValue)));

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -127,7 +127,7 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        customerListPanel = new CustomerListPanel(logic.getFilteredCustomerList(), logic::selectCustomer,
+        customerListPanel = new CustomerListPanel(logic.getSortedFilteredCustomerList(), logic::selectCustomer,
                 logic.getSelectedCustomer());
         customerListPanelPlaceholder.getChildren().add(customerListPanel.getRoot());
 

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -89,8 +89,8 @@ public class LogicManagerTest {
     }
 
     @Test
-    public void getFilteredCustomerList_modifyList_throwsUnsupportedOperationException() {
-        assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredCustomerList().remove(0));
+    public void getSortedFilteredCustomerList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> logic.getSortedFilteredCustomerList().remove(0));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCustomerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCustomerCommandTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.ObservableObject;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ModelStub;
@@ -34,6 +35,7 @@ public class AddCustomerCommandTest {
         assertEquals(String.format(AddCustomerCommand.MESSAGE_SUCCESS, validCustomer),
                 commandResult.getFeedbackToUser());
         assertEquals(Collections.singletonList(validCustomer), modelStub.customersAdded);
+        assertEquals(validCustomer, modelStub.getSelectedCustomer().getValue());
     }
 
     @Test
@@ -93,6 +95,7 @@ public class AddCustomerCommandTest {
      */
     private static class ModelStubAcceptingCustomerAdded extends ModelStub {
         final ArrayList<Customer> customersAdded = new ArrayList<>();
+        private final ObservableObject<Customer> selectedCustomer = new ObservableObject<>();
 
         @Override
         public boolean hasCustomer(Customer customer) {
@@ -109,6 +112,16 @@ public class AddCustomerCommandTest {
         @Override
         public ReadOnlyAddressBook getAddressBook() {
             return new AddressBook();
+        }
+
+        @Override
+        public ObservableObject<Customer> getSelectedCustomer() {
+            return selectedCustomer;
+        }
+
+        @Override
+        public void selectCustomer(Customer customer) {
+            selectedCustomer.setValue(customer);
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -121,11 +121,11 @@ public class CommandTestUtil {
         // we are unable to defensively copy the model for comparison later, so we can
         // only do so by copying its components.
         AddressBook expectedAddressBook = new AddressBook(actualModel.getAddressBook());
-        List<Customer> expectedFilteredList = new ArrayList<>(actualModel.getFilteredCustomerList());
+        List<Customer> expectedFilteredList = new ArrayList<>(actualModel.getSortedFilteredCustomerList());
 
         assertThrows(CommandException.class, expectedMessage, () -> command.execute(actualModel));
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
-        assertEquals(expectedFilteredList, actualModel.getFilteredCustomerList());
+        assertEquals(expectedFilteredList, actualModel.getSortedFilteredCustomerList());
     }
 
     /**
@@ -133,13 +133,13 @@ public class CommandTestUtil {
      * {@code model}'s address book.
      */
     public static void showCustomerAtIndex(Model model, Index targetIndex) {
-        assertTrue(targetIndex.getZeroBased() < model.getFilteredCustomerList().size());
+        assertTrue(targetIndex.getZeroBased() < model.getSortedFilteredCustomerList().size());
 
-        Customer customer = model.getFilteredCustomerList().get(targetIndex.getZeroBased());
+        Customer customer = model.getSortedFilteredCustomerList().get(targetIndex.getZeroBased());
         final String[] splitName = customer.getName().fullName.split("\\s+");
         model.updateFilteredCustomerList(new NameContainsKeywordsPredicate(Collections.singletonList(splitName[0])));
 
-        assertEquals(1, model.getFilteredCustomerList().size());
+        assertEquals(1, model.getSortedFilteredCustomerList().size());
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommissionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommissionCommandTest.java
@@ -34,7 +34,7 @@ class DeleteCommissionCommandTest {
 
     @Test
     public void execute_validIndex_success() {
-        model.selectCustomer(model.getFilteredCustomerList().get(0));
+        model.selectCustomer(model.getSortedFilteredCustomerList().get(0));
         model.getSelectedCustomer().getValue().addCommission(
                 DOG_PRODUCER.apply(model.getSelectedCustomer().getValue()));
         Commission commissionToDelete = model.getFilteredCommissionList().get(0);
@@ -51,7 +51,7 @@ class DeleteCommissionCommandTest {
 
     @Test
     public void execute_indexTooHigh_throwsCommandException() {
-        model.selectCustomer(model.getFilteredCustomerList().get(0));
+        model.selectCustomer(model.getSortedFilteredCustomerList().get(0));
         DeleteCommissionCommand deleteCommissionCommand = new DeleteCommissionCommand(INDEX_FIRST);
         assertCommandFailure(deleteCommissionCommand, model, Messages.MESSAGE_INVALID_COMMISSION_DISPLAYED_INDEX);
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteCustomerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCustomerCommandTest.java
@@ -29,7 +29,7 @@ public class DeleteCustomerCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        Customer customerToDelete = model.getFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
+        Customer customerToDelete = model.getSortedFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
         DeleteCustomerCommand deleteCommand = new DeleteCustomerCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(DeleteCustomerCommand.MESSAGE_DELETE_CUSTOMER_SUCCESS, customerToDelete);
@@ -42,7 +42,7 @@ public class DeleteCustomerCommandTest {
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredCustomerList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(model.getSortedFilteredCustomerList().size() + 1);
         DeleteCustomerCommand deleteCommand = new DeleteCustomerCommand(outOfBoundIndex);
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_CUSTOMER_DISPLAYED_INDEX);
@@ -52,7 +52,7 @@ public class DeleteCustomerCommandTest {
     public void execute_validIndexFilteredList_success() {
         showCustomerAtIndex(model, INDEX_FIRST);
 
-        Customer customerToDelete = model.getFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
+        Customer customerToDelete = model.getSortedFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
         DeleteCustomerCommand deleteCommand = new DeleteCustomerCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(DeleteCustomerCommand.MESSAGE_DELETE_CUSTOMER_SUCCESS, customerToDelete);
@@ -105,6 +105,6 @@ public class DeleteCustomerCommandTest {
     private void showNoCustomer(Model model) {
         model.updateFilteredCustomerList(p -> false);
 
-        assertTrue(model.getFilteredCustomerList().isEmpty());
+        assertTrue(model.getSortedFilteredCustomerList().isEmpty());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -43,15 +43,15 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CUSTOMER_SUCCESS, editedCustomer);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setCustomer(model.getFilteredCustomerList().get(0), editedCustomer);
+        expectedModel.setCustomer(model.getSortedFilteredCustomerList().get(0), editedCustomer);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_someFieldsSpecifiedUnfilteredList_success() {
-        Index indexLastCustomer = Index.fromOneBased(model.getFilteredCustomerList().size());
-        Customer lastCustomer = model.getFilteredCustomerList().get(indexLastCustomer.getZeroBased());
+        Index indexLastCustomer = Index.fromOneBased(model.getSortedFilteredCustomerList().size());
+        Customer lastCustomer = model.getSortedFilteredCustomerList().get(indexLastCustomer.getZeroBased());
 
         CustomerBuilder customerInList = new CustomerBuilder(lastCustomer);
         Customer editedCustomer = customerInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
@@ -72,7 +72,7 @@ public class EditCommandTest {
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
         EditCommand editCommand = new EditCommand(INDEX_FIRST, new EditCustomerDescriptor());
-        Customer customerInFilteredList = model.getFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
+        Customer customerInFilteredList = model.getSortedFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
         Customer editedCustomer = new CustomerBuilder(customerInFilteredList).withoutAddress().build();
         model.setCustomer(customerInFilteredList, editedCustomer);
 
@@ -87,7 +87,7 @@ public class EditCommandTest {
     public void execute_filteredList_success() {
         showCustomerAtIndex(model, INDEX_FIRST);
 
-        Customer customerInFilteredList = model.getFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
+        Customer customerInFilteredList = model.getSortedFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
         Customer editedCustomer = new CustomerBuilder(customerInFilteredList).withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST,
                 new EditCustomerDescriptorBuilder().withName(VALID_NAME_BOB).build());
@@ -95,14 +95,14 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CUSTOMER_SUCCESS, editedCustomer);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setCustomer(model.getFilteredCustomerList().get(0), editedCustomer);
+        expectedModel.setCustomer(model.getSortedFilteredCustomerList().get(0), editedCustomer);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_duplicateCustomerUnfilteredList_failure() {
-        Customer firstCustomer = model.getFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
+        Customer firstCustomer = model.getSortedFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
         EditCustomerDescriptor descriptor = new EditCustomerDescriptorBuilder(firstCustomer).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND, descriptor);
 
@@ -123,7 +123,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_invalidCustomerIndexUnfilteredList_failure() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredCustomerList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(model.getSortedFilteredCustomerList().size() + 1);
         EditCustomerDescriptor descriptor = new EditCustomerDescriptorBuilder().withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -61,7 +61,7 @@ public class FindCommandTest {
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredCustomerList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredCustomerList());
+        assertEquals(Collections.emptyList(), model.getSortedFilteredCustomerList());
     }
 
     @Test
@@ -71,7 +71,7 @@ public class FindCommandTest {
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredCustomerList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredCustomerList());
+        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getSortedFilteredCustomerList());
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/OpenCommissionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/OpenCommissionCommandTest.java
@@ -36,7 +36,7 @@ class OpenCommissionCommandTest {
 
     @Test
     public void execute_validIndex_success() {
-        model.selectCustomer(model.getFilteredCustomerList().get(0));
+        model.selectCustomer(model.getSortedFilteredCustomerList().get(0));
         model.getSelectedCustomer().getValue().addCommission(
                 DOG_PRODUCER.apply(model.getSelectedCustomer().getValue()));
         model.getSelectedCustomer().getValue().addCommission(
@@ -60,7 +60,7 @@ class OpenCommissionCommandTest {
 
     @Test
     public void execute_indexTooHigh_throwsCommandException() {
-        model.selectCustomer(model.getFilteredCustomerList().get(0));
+        model.selectCustomer(model.getSortedFilteredCustomerList().get(0));
         OpenCommissionCommand openCommissionCommand = new OpenCommissionCommand(INDEX_FIRST);
         assertCommandFailure(openCommissionCommand, model, Messages.MESSAGE_INVALID_COMMISSION_DISPLAYED_INDEX);
     }

--- a/src/test/java/seedu/address/logic/commands/OpenCustomerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/OpenCustomerCommandTest.java
@@ -28,7 +28,7 @@ public class OpenCustomerCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        Customer customerToDelete = model.getFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
+        Customer customerToDelete = model.getSortedFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
         OpenCustomerCommand openCommand = new OpenCustomerCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(OpenCustomerCommand.MESSAGE_OPEN_CUSTOMER_SUCCESS, customerToDelete);
@@ -40,7 +40,7 @@ public class OpenCustomerCommandTest {
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredCustomerList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(model.getSortedFilteredCustomerList().size() + 1);
         OpenCustomerCommand openCustomerCommand = new OpenCustomerCommand(outOfBoundIndex);
 
         assertCommandFailure(openCustomerCommand, model, Messages.MESSAGE_INVALID_CUSTOMER_DISPLAYED_INDEX);
@@ -50,7 +50,7 @@ public class OpenCustomerCommandTest {
     public void execute_validIndexFilteredList_success() {
         showCustomerAtIndex(model, INDEX_FIRST);
 
-        Customer customerToOpen = model.getFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
+        Customer customerToOpen = model.getSortedFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
         OpenCustomerCommand openCommand = new OpenCustomerCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(OpenCustomerCommand.MESSAGE_OPEN_CUSTOMER_SUCCESS, customerToOpen);
@@ -102,6 +102,6 @@ public class OpenCustomerCommandTest {
     private void showNoCustomer(Model model) {
         model.updateFilteredCustomerList(p -> false);
 
-        assertTrue(model.getFilteredCustomerList().isEmpty());
+        assertTrue(model.getSortedFilteredCustomerList().isEmpty());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/SortCustomerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCustomerCommandTest.java
@@ -1,0 +1,65 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.commons.core.Messages.MESSAGE_CUSTOMERS_SORTED;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.model.Model.CUSTOMER_NAME_COMPARATOR;
+import static seedu.address.model.Model.CUSTOMER_REVENUE_COMPARATOR;
+import static seedu.address.testutil.TypicalCustomers.ALICE;
+import static seedu.address.testutil.TypicalCustomers.BENSON;
+import static seedu.address.testutil.TypicalCustomers.CARL;
+import static seedu.address.testutil.TypicalCustomers.DANIEL;
+import static seedu.address.testutil.TypicalCustomers.ELLE;
+import static seedu.address.testutil.TypicalCustomers.FIONA;
+import static seedu.address.testutil.TypicalCustomers.GEORGE;
+import static seedu.address.testutil.TypicalCustomers.getTypicalAddressBook;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.util.SortDirection;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code SortCustomerCommand}.
+ */
+public class SortCustomerCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private final Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    }
+
+
+    @Test
+    public void execute_nameSort_sortsProperly() {
+        String expectedMessage = String.format(MESSAGE_CUSTOMERS_SORTED, 7, SortDirection.DECREASING, "description");
+        SortCustomerCommand command = new SortCustomerCommand(
+                CUSTOMER_NAME_COMPARATOR.reversed(), "description", SortDirection.DECREASING);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(GEORGE, FIONA, ELLE, DANIEL, CARL, BENSON, ALICE),
+                model.getSortedFilteredCustomerList());
+    }
+
+    @Test
+    public void equals() {
+        SortCustomerCommand nameSort = new SortCustomerCommand(CUSTOMER_NAME_COMPARATOR, "name",
+                SortDirection.INCREASING);
+        SortCustomerCommand nameSort1 = new SortCustomerCommand(CUSTOMER_NAME_COMPARATOR, "name",
+            SortDirection.INCREASING);
+        SortCustomerCommand nameSortDecreasing = new SortCustomerCommand(CUSTOMER_NAME_COMPARATOR.reversed(), "name",
+            SortDirection.DECREASING);
+        SortCustomerCommand revenueSort = new SortCustomerCommand(CUSTOMER_REVENUE_COMPARATOR.reversed(), "revenue",
+            SortDirection.DECREASING);
+        assertEquals(nameSort, nameSort1);
+        assertNotEquals(nameSort, nameSortDecreasing);
+        assertNotEquals(nameSort, revenueSort);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -9,12 +9,12 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCustomerCommand;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.DeleteCommissionCommand;
 import seedu.address.logic.commands.DeleteCustomerCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditCustomerDescriptor;
@@ -23,6 +23,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.OpenCustomerCommand;
+import seedu.address.logic.commands.SortCustomerCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.customer.Customer;
 import seedu.address.model.customer.NameContainsKeywordsPredicate;
@@ -81,7 +82,7 @@ public class AddressBookParserTest {
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+                FindCommand.COMMAND_WORD + " " + String.join(" ", keywords));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
     }
 
@@ -96,6 +97,19 @@ public class AddressBookParserTest {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
     }
+
+    @Test
+    public void parseCommand_deleteCommission() throws Exception {
+        DeleteCommissionCommand command = (DeleteCommissionCommand) parser.parseCommand(
+            DeleteCommissionCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased());
+        assertEquals(new DeleteCommissionCommand(INDEX_FIRST), command);
+    }
+
+    @Test
+    public void parseCommand_sortCustomer() throws Exception {
+        assertTrue(parser.parseCommand(SortCustomerCommand.COMMAND_WORD + " n/+") instanceof SortCustomerCommand);
+    }
+
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {

--- a/src/test/java/seedu/address/logic/parser/SortCustomerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCustomerCommandParserTest.java
@@ -1,0 +1,55 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_UNIQUE_COMPARATOR;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_CUSTOMER_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_CUSTOMER_REVENUE;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.SortCustomerCommand;
+import seedu.address.model.util.SortDirection;
+
+public class SortCustomerCommandParserTest {
+    private final SortCustomerCommandParser parser = new SortCustomerCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                SortCustomerCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsSortCustomerByNameIncreasingCommand() {
+        // no leading and trailing whitespaces
+        SortCustomerCommand expectedSortCustomerCommand = SortCustomerCommandParser.convertPrefixDescriptionEntry(
+                SortCustomerCommandParser.PREFIX_DESCRIPTION_MAP.get(PREFIX_SORT_CUSTOMER_NAME),
+                SortDirection.INCREASING);
+        assertParseSuccess(parser, " " + PREFIX_SORT_CUSTOMER_NAME + "+", expectedSortCustomerCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " " + PREFIX_SORT_CUSTOMER_NAME + "   + ", expectedSortCustomerCommand);
+    }
+
+    @Test
+    public void parse_validArgs_returnsSortCustomerByRevenueDecreasingCommand() {
+        // no leading and trailing whitespaces
+        SortCustomerCommand expectedSortCustomerCommand = SortCustomerCommandParser.convertPrefixDescriptionEntry(
+            SortCustomerCommandParser.PREFIX_DESCRIPTION_MAP.get(PREFIX_SORT_CUSTOMER_REVENUE),
+            SortDirection.DECREASING);
+        assertParseSuccess(parser, " " + PREFIX_SORT_CUSTOMER_REVENUE + "-", expectedSortCustomerCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " " + PREFIX_SORT_CUSTOMER_REVENUE + "   - ", expectedSortCustomerCommand);
+    }
+
+    @Test
+    public void parse_multipleComparators_throwsParseException() {
+        // no leading and trailing whitespaces
+        assertParseFailure(parser, " " + PREFIX_SORT_CUSTOMER_NAME + "-"
+                + " " + PREFIX_SORT_CUSTOMER_REVENUE + "-", MESSAGE_INVALID_UNIQUE_COMPARATOR);
+    }
+
+}

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -117,8 +117,8 @@ public class ModelManagerTest {
     }
 
     @Test
-    public void getFilteredCustomerList_modifyList_throwsUnsupportedOperationException() {
-        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredCustomerList().remove(0));
+    public void getSortedFilteredCustomerList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getSortedFilteredCustomerList().remove(0));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -16,6 +16,8 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
+import javafx.collections.transformation.FilteredList;
+import javafx.util.Pair;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.commission.Commission;
 import seedu.address.model.customer.Customer;
@@ -120,17 +122,31 @@ public class ModelManagerTest {
     }
 
     @Test
-    public void selectCustomer_newCustomer_resetsSelectedCommission() {
+    public void selectCustomer_newCustomer_selectsNewCustomer() {
         Customer testCustomer = new CustomerBuilder(ALICE).build();
         modelManager.addCustomer(testCustomer);
         Commission testCommission = new CommissionBuilder().build(testCustomer);
         testCustomer.addCommission(testCommission);
-        modelManager.addCustomer(BENSON);
         modelManager.selectCustomer(testCustomer);
-        modelManager.selectCommission(testCommission);
-        assertEquals(testCommission, modelManager.getSelectedCommission().getValue());
+        assertEquals(testCustomer, modelManager.getSelectedCustomer().getValue());
+        modelManager.addCustomer(BENSON);
         modelManager.selectCustomer(BENSON);
+        assertEquals(BENSON, modelManager.getSelectedCustomer().getValue());
+        modelManager.selectCustomer(null);
         assertNull(modelManager.getSelectedCommission().getValue());
+    }
+
+    @Test
+    public void addCommission_emptyList_updatesObservableList() {
+        Customer aliceCopy = new CustomerBuilder(ALICE).build();
+        modelManager.selectCustomer(null);
+        Pair<Customer, FilteredList<Commission>> originalList =
+                modelManager.getObservableFilteredCommissionList().getValue();
+        modelManager.addCustomer(aliceCopy);
+        Commission testCommission = new CommissionBuilder().build(aliceCopy);
+        modelManager.selectCustomer(aliceCopy);
+        aliceCopy.addCommission(testCommission);
+        assertNotEquals(originalList, modelManager.getObservableFilteredCommissionList().getValue());
     }
 
 

--- a/src/test/java/seedu/address/model/ModelStub.java
+++ b/src/test/java/seedu/address/model/ModelStub.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -81,12 +82,17 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public ObservableList<Customer> getFilteredCustomerList() {
+    public ObservableList<Customer> getSortedFilteredCustomerList() {
         throw new AssertionError("This method should not be called.");
     }
 
     @Override
     public void updateFilteredCustomerList(Predicate<Customer> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateSortedCustomerList(Comparator<Customer> comparator) {
         throw new AssertionError("This method should not be called.");
     }
 

--- a/src/test/java/seedu/address/model/ModelStub.java
+++ b/src/test/java/seedu/address/model/ModelStub.java
@@ -3,9 +3,9 @@ package seedu.address.model;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 
-import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.util.Pair;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.ObservableObject;
 import seedu.address.model.commission.Commission;
@@ -96,7 +96,7 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public ObservableValue<FilteredList<Commission>> getObservableFilteredCommissionList() {
+    public ObservableObject<Pair<Customer, FilteredList<Commission>>> getObservableFilteredCommissionList() {
         throw new AssertionError("This method should not be called.");
     }
 

--- a/src/test/java/seedu/address/model/customer/CustomerTest.java
+++ b/src/test/java/seedu/address/model/customer/CustomerTest.java
@@ -65,8 +65,9 @@ public class CustomerTest {
 
     @Test
     public void equals() {
+        Customer alice = new CustomerBuilder(ALICE).build();
         // same values -> returns true
-        Customer aliceCopy = new CustomerBuilder(ALICE).build();
+        Customer aliceCopy = new CustomerBuilder(alice).build();
         assertTrue(ALICE.equals(aliceCopy));
 
         // same object -> returns true

--- a/src/test/java/seedu/address/model/util/SortDirectionTest.java
+++ b/src/test/java/seedu/address/model/util/SortDirectionTest.java
@@ -1,0 +1,53 @@
+package seedu.address.model.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class SortDirectionTest {
+    private static final SortDirection INCREASING = new SortDirection("+");
+    private static final SortDirection DECREASING = new SortDirection("-");
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new SortDirection(null));
+    }
+
+    @Test
+    public void constructor_invalidSortDirection_throwsIllegalArgumentException() {
+        String[] invalidDirections = new String[] {
+            "",
+            "yes",
+            "decreasing"
+        };
+        for (String input : invalidDirections) {
+            assertThrows(IllegalArgumentException.class, () -> new SortDirection(input));
+        }
+    }
+
+    @Test
+    public void testIsIncreasing() {
+        assertTrue(INCREASING.isIncreasing());
+        assertFalse(DECREASING.isIncreasing());
+    }
+
+    @Test
+    public void equals() {
+        // same object -> returns true
+        assertEquals(INCREASING, new SortDirection("+"));
+        assertNotEquals(INCREASING, DECREASING);
+        assertEquals(DECREASING, new SortDirection("-"));
+        assertEquals(INCREASING.hashCode(), INCREASING.hashCode());
+    }
+
+    @Test
+    public void testToString() {
+        // same object -> returns true
+        assertEquals("increasing", INCREASING.toString());
+        assertEquals("decreasing", DECREASING.toString());
+    }
+}

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -36,20 +36,20 @@ public class TestUtil {
      * Returns the middle index of the customer in the {@code model}'s customer list.
      */
     public static Index getMidIndex(Model model) {
-        return Index.fromOneBased(model.getFilteredCustomerList().size() / 2);
+        return Index.fromOneBased(model.getSortedFilteredCustomerList().size() / 2);
     }
 
     /**
      * Returns the last index of the customer in the {@code model}'s customer list.
      */
     public static Index getLastIndex(Model model) {
-        return Index.fromOneBased(model.getFilteredCustomerList().size());
+        return Index.fromOneBased(model.getSortedFilteredCustomerList().size());
     }
 
     /**
      * Returns the customer in the {@code model}'s customer list at {@code index}.
      */
     public static Customer getCustomer(Model model, Index index) {
-        return model.getFilteredCustomerList().get(index.getZeroBased());
+        return model.getSortedFilteredCustomerList().get(index.getZeroBased());
     }
 }


### PR DESCRIPTION
- Implement basic sort functionality
- Wrap FilteredList in SortedList to be passed into UI.

Currently only supports a single comparator. Supporting multiple comparators would need a way to preserve the order of arguments being parsed by the user.

How this sorting is implemented:
- user would enter `sortcus n/+` to sort in increasing order based on the customer's name.
- We can specify more comparators within `Model.java`
- Sorting by commissions across all customers would require implementing support for displaying the full list of commissions across different customers and specifying what happens for each command if there are no active customers selected

Move `arePrefixesPresent` to ParserUtil to avoid duplication


Combine with #104 
## Fix issue with UniqueCommissionLists of different customers having the same hash
Wrap observableCommissionsList in a Pair with customer

There is an issue where two identical UniqueCommissionLists for different customers would have the same hash and switching between customers with identical lists would not trigger the change listener for the observableFilteredCommissions.
Avoid deselecting the current item if it is not modified by the previous command