### PR TITLE
Fix: stop invalid data from crashing the app

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -31,10 +31,11 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final SortedList<Customer> sortedFilteredCustomers;
     private final FilteredList<Customer> filteredCustomers;
-    private final ObservableObject<Pair<Customer, FilteredList<Commission>>> observableFilteredCommissions =
-            new ObservableObject<>();
     private final ObservableObject<Pair<Customer, UniqueCommissionList>> observableUniqueCommissions =
-            new ObservableObject<>();
+            new ObservableObject<>(new Pair<>(null, new UniqueCommissionList()));
+    private final ObservableObject<Pair<Customer, FilteredList<Commission>>> observableFilteredCommissions =
+            new ObservableObject<>(new Pair<>(null, new FilteredList<>(
+                    observableUniqueCommissions.getValue().getValue().asUnmodifiableObservableList())));
     private final ObservableObject<Customer> selectedCustomer = new ObservableObject<>();
     private final ObservableObject<Commission> selectedCommission = new ObservableObject<>();
 

--- a/src/main/java/seedu/address/ui/CommissionListPanel.java
+++ b/src/main/java/seedu/address/ui/CommissionListPanel.java
@@ -33,7 +33,9 @@ public class CommissionListPanel extends UiPart<Region> {
                                Consumer<Commission> selectCommission,
                                ObservableObject<Commission> selectedCommission) {
         super(FXML);
-        this.updateUI(observableCommissionList.getValue().getValue());
+        if (observableCommissionList.getValue() != null) {
+            this.updateUI(observableCommissionList.getValue().getValue());
+        }
         this.selectCommission = selectCommission;
 
         observableCommissionList.addListener((observable, oldValue, newValue) -> this.updateUI(newValue.getValue()));


### PR DESCRIPTION
Currently, the CommissionListPanel does not check if observableCommissionList is null (unlike
`ModelManager#getFilteredCommissionList()`, that does.)

Invalid data will force an empty addressbook (e.g set fee to negative) - making the observableCommissionList null and causing a NullPointerException on running the app.

Let's add a null check to fix this.

Closes #115 