### PR TITLE
Add support for `opencom` and `opencus` without index

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -29,4 +29,10 @@ public class Messages {
     public static final String MESSAGE_NONEXISTENT_IMAGE_PATH = "The image path provided does not exist";
     public static final String MESSAGE_NOT_AN_IMAGE = "The file at the given path is not an image";
     public static final String MESSAGE_INVALID_PATH = "The path provided was invalid: %1$s";
+
+
+    public static final String MESSAGE_OPEN_CUSTOMER_SUCCESS = "Opened Customer: %1$s";
+    public static final String MESSAGE_OPEN_CUSTOMER_TAB_SUCCESS = "Opened Customer tab";
+    public static final String MESSAGE_OPEN_COMMISSION_TAB_SUCCESS = "Opened Commission Tab";
+    public static final String MESSAGE_OPEN_COMMISSION_SUCCESS = "Opened Commission: %1$s";
 }

--- a/src/main/java/seedu/address/logic/commands/OpenCommissionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/OpenCommissionCommand.java
@@ -1,8 +1,11 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_OPEN_COMMISSION_SUCCESS;
+import static seedu.address.commons.core.Messages.MESSAGE_OPEN_COMMISSION_TAB_SUCCESS;
 
 import java.util.List;
+import java.util.Objects;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -23,12 +26,18 @@ public class OpenCommissionCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_OPEN_COMMISSION_SUCCESS = "Opened Commission: %1$s";
 
     private final Index targetIndex;
 
+    /** Creates an {@code OpenCommissionCommand} to open the specified commission at the given `targetIndex`. */
     public OpenCommissionCommand(Index targetIndex) {
+        requireNonNull(targetIndex);
         this.targetIndex = targetIndex;
+    }
+
+    /** Creates an {@code OpenCommissionCommand} to open the commissions tab. */
+    public OpenCommissionCommand() {
+        this.targetIndex = null;
     }
 
     @Override
@@ -37,6 +46,11 @@ public class OpenCommissionCommand extends Command {
 
         if (!model.hasSelectedCustomer()) {
             throw new CommandException(Messages.MESSAGE_NO_ACTIVE_CUSTOMER);
+        }
+        model.selectTab(GuiTab.COMMISSION);
+
+        if (targetIndex == null) {
+            return new CommandResult(MESSAGE_OPEN_COMMISSION_TAB_SUCCESS);
         }
 
         List<Commission> lastShownList = model.getFilteredCommissionList();
@@ -47,14 +61,17 @@ public class OpenCommissionCommand extends Command {
 
         Commission commissionToOpen = lastShownList.get(targetIndex.getZeroBased());
         model.selectCommission(commissionToOpen);
-        model.selectTab(GuiTab.COMMISSION);
         return new CommandResult(String.format(MESSAGE_OPEN_COMMISSION_SUCCESS, commissionToOpen));
     }
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof OpenCommissionCommand // instanceof handles nulls
-                && targetIndex.equals(((OpenCommissionCommand) other).targetIndex)); // state check
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof OpenCommissionCommand)) {
+            return false;
+        }
+        return Objects.equals(targetIndex, ((OpenCommissionCommand) other).targetIndex);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/OpenCustomerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/OpenCustomerCommand.java
@@ -1,8 +1,11 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_OPEN_CUSTOMER_SUCCESS;
+import static seedu.address.commons.core.Messages.MESSAGE_OPEN_CUSTOMER_TAB_SUCCESS;
 
 import java.util.List;
+import java.util.Objects;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -24,19 +27,27 @@ public class OpenCustomerCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_OPEN_CUSTOMER_SUCCESS = "Opened Customer: %1$s";
-
     private final Index targetIndex;
 
     public OpenCustomerCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
     }
 
+    public OpenCustomerCommand() {
+        this.targetIndex = null;
+    }
+
     @Override
     public CommandResult execute(Model model, Storage...storage) throws CommandException {
         requireNonNull(model);
 
+
+        model.selectTab(GuiTab.CUSTOMER);
         List<Customer> lastShownList = model.getSortedFilteredCustomerList();
+
+        if (targetIndex == null) {
+            return new CommandResult(MESSAGE_OPEN_CUSTOMER_TAB_SUCCESS);
+        }
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CUSTOMER_DISPLAYED_INDEX);
@@ -44,14 +55,17 @@ public class OpenCustomerCommand extends Command {
 
         Customer customerToOpen = lastShownList.get(targetIndex.getZeroBased());
         model.selectCustomer(customerToOpen);
-        model.selectTab(GuiTab.CUSTOMER);
         return new CommandResult(String.format(MESSAGE_OPEN_CUSTOMER_SUCCESS, customerToOpen));
     }
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof OpenCustomerCommand // instanceof handles nulls
-                && targetIndex.equals(((OpenCustomerCommand) other).targetIndex)); // state check
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof OpenCustomerCommand)) {
+            return false;
+        }
+        return Objects.equals(targetIndex, ((OpenCustomerCommand) other).targetIndex);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/OpenCustomerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/OpenCustomerCommand.java
@@ -41,7 +41,6 @@ public class OpenCustomerCommand extends Command {
     public CommandResult execute(Model model, Storage...storage) throws CommandException {
         requireNonNull(model);
 
-
         model.selectTab(GuiTab.CUSTOMER);
         List<Customer> lastShownList = model.getSortedFilteredCustomerList();
 

--- a/src/main/java/seedu/address/logic/parser/OpenCommissionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/OpenCommissionCommandParser.java
@@ -18,6 +18,10 @@ public class OpenCommissionCommandParser implements Parser<OpenCommissionCommand
      */
     public OpenCommissionCommand parse(String args) throws ParseException {
         try {
+            String trimmedArgs = args.trim();
+            if (trimmedArgs.isEmpty()) {
+                return new OpenCommissionCommand();
+            }
             Index index = ParserUtil.parseIndex(args);
             return new OpenCommissionCommand(index);
         } catch (ParseException pe) {

--- a/src/main/java/seedu/address/logic/parser/OpenCustomerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/OpenCustomerCommandParser.java
@@ -18,6 +18,10 @@ public class OpenCustomerCommandParser implements Parser<OpenCustomerCommand> {
      */
     public OpenCustomerCommand parse(String args) throws ParseException {
         try {
+            String trimmedArgs = args.trim();
+            if (trimmedArgs.isEmpty()) {
+                return new OpenCustomerCommand();
+            }
             Index index = ParserUtil.parseIndex(args);
             return new OpenCustomerCommand(index);
         } catch (ParseException pe) {

--- a/src/test/java/seedu/address/logic/commands/OpenCommissionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/OpenCommissionCommandTest.java
@@ -19,6 +19,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.commission.Commission;
+import seedu.address.ui.GuiTab;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -35,6 +36,14 @@ class OpenCommissionCommandTest {
     }
 
     @Test
+    public void execute_noIndex_switchesTab() {
+        model.selectCustomer(model.getSortedFilteredCustomerList().get(0));
+        CommandResult result = assertDoesNotThrow(() -> new OpenCommissionCommand().execute(model));
+        assertEquals(result.getFeedbackToUser(), Messages.MESSAGE_OPEN_COMMISSION_TAB_SUCCESS);
+        assertEquals(model.getSelectedTab(), GuiTab.COMMISSION);
+    }
+
+    @Test
     public void execute_validIndex_success() {
         model.selectCustomer(model.getSortedFilteredCustomerList().get(0));
         model.getSelectedCustomer().getValue().addCommission(
@@ -45,7 +54,7 @@ class OpenCommissionCommandTest {
         Commission commissionToOpen = model.getFilteredCommissionList().get(1);
         OpenCommissionCommand openCommissionCommand = new OpenCommissionCommand(INDEX_SECOND);
 
-        String expectedMessage = String.format(OpenCommissionCommand.MESSAGE_OPEN_COMMISSION_SUCCESS,
+        String expectedMessage = String.format(Messages.MESSAGE_OPEN_COMMISSION_SUCCESS,
                 commissionToOpen);
 
         CommandResult result = assertDoesNotThrow(() -> openCommissionCommand.execute(model));

--- a/src/test/java/seedu/address/logic/commands/OpenCustomerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/OpenCustomerCommandTest.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
@@ -17,6 +19,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.customer.Customer;
+import seedu.address.ui.GuiTab;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -31,7 +34,7 @@ public class OpenCustomerCommandTest {
         Customer customerToDelete = model.getSortedFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
         OpenCustomerCommand openCommand = new OpenCustomerCommand(INDEX_FIRST);
 
-        String expectedMessage = String.format(OpenCustomerCommand.MESSAGE_OPEN_CUSTOMER_SUCCESS, customerToDelete);
+        String expectedMessage = String.format(Messages.MESSAGE_OPEN_CUSTOMER_SUCCESS, customerToDelete);
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
@@ -53,7 +56,7 @@ public class OpenCustomerCommandTest {
         Customer customerToOpen = model.getSortedFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
         OpenCustomerCommand openCommand = new OpenCustomerCommand(INDEX_FIRST);
 
-        String expectedMessage = String.format(OpenCustomerCommand.MESSAGE_OPEN_CUSTOMER_SUCCESS, customerToOpen);
+        String expectedMessage = String.format(Messages.MESSAGE_OPEN_CUSTOMER_SUCCESS, customerToOpen);
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         showCustomerAtIndex(expectedModel, INDEX_FIRST);
@@ -72,6 +75,14 @@ public class OpenCustomerCommandTest {
         OpenCustomerCommand openCommand = new OpenCustomerCommand(outOfBoundIndex);
 
         assertCommandFailure(openCommand, model, Messages.MESSAGE_INVALID_CUSTOMER_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_noIndex_switchesTab() {
+        model = new ModelManager();
+        CommandResult result = assertDoesNotThrow(() -> new OpenCustomerCommand().execute(model));
+        assertEquals(result.getFeedbackToUser(), Messages.MESSAGE_OPEN_CUSTOMER_TAB_SUCCESS);
+        assertEquals(model.getSelectedTab(), GuiTab.CUSTOMER);
     }
 
     @Test


### PR DESCRIPTION
Add support for `opencom` and `opencus` without index

- allows the user to switch tabs to view customer/commission without having to select any item in the list.