### PR TITLE
GUI OS Bugs

### DIFF
--- a/src/main/java/seedu/address/ui/command/window/AddIterationWindow.java
+++ b/src/main/java/seedu/address/ui/command/window/AddIterationWindow.java
@@ -9,6 +9,7 @@ import java.util.function.Consumer;
 
 import javafx.stage.Stage;
 import seedu.address.logic.commands.iteration.AddIterationCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.ui.CommandBox;
 import seedu.address.ui.UiPart;
 
@@ -18,6 +19,7 @@ import seedu.address.ui.UiPart;
 public class AddIterationWindow extends IterationWindow {
 
     private static final String ADD_ITERATION_WINDOW_NAME = "Add Iteration";
+    private static final String ERROR_NO_IMAGE_PROVIDED = "Please select an image.";
 
     /**
      * Creates a new AddIterationWindow.
@@ -33,15 +35,24 @@ public class AddIterationWindow extends IterationWindow {
      */
     @Override
     public void handleIterationCommand() {
-        String addIterationCommand = getAddIterationCommand();
-        executeIterationCommand(addIterationCommand);
+        try {
+            String addIterationCommand = getAddIterationCommand();
+            executeIterationCommand(addIterationCommand);
+        } catch (ParseException e) {
+            setErrorMessage(e.getMessage());
+        }
     }
 
-    private String getAddIterationCommand() {
+    private String getAddIterationCommand() throws ParseException {
         String addIterationCommandInput = AddIterationCommand.COMMAND_WORD + " ";
         addIterationCommandInput += PREFIX_ITERATION_DATE + getDateInput() + " ";
         addIterationCommandInput += PREFIX_ITERATION_DESCRIPTION + getDescriptionInput() + " ";
         addIterationCommandInput += PREFIX_ITERATION_FEEDBACK + getFeedbackInput() + " ";
+
+        if (getImagePathInput().isBlank()) {
+            throw new ParseException(ERROR_NO_IMAGE_PROVIDED);
+        }
+
         addIterationCommandInput += PREFIX_ITERATION_IMAGEPATH + getImagePathInput();
         return addIterationCommandInput;
     }

--- a/src/main/java/seedu/address/ui/command/window/IterationWindow.java
+++ b/src/main/java/seedu/address/ui/command/window/IterationWindow.java
@@ -121,6 +121,13 @@ public abstract class IterationWindow extends UiPart<Stage> {
     }
 
     /**
+     * Sets the error message display to the specified message.
+     */
+    void setErrorMessage(String message) {
+        errorDisplay.setError(message);
+    }
+
+    /**
      * Executes a given command by the GUI window.
      */
     public void executeIterationCommand(String iterationCommandInput) {
@@ -129,7 +136,7 @@ public abstract class IterationWindow extends UiPart<Stage> {
             handleCloseIterationWindow();
             windowStage.close();
         } catch (CommandException | ParseException e) {
-            errorDisplay.setError(e.getMessage());
+            setErrorMessage(e.getMessage());
         }
     }
 

--- a/src/main/resources/view/CommissionWindow.fxml
+++ b/src/main/resources/view/CommissionWindow.fxml
@@ -47,20 +47,16 @@
                     <VBox spacing="12">
                         <HBox fx:id="errorMessagePlaceholder" alignment="CENTER"/>
                         <HBox>
-                            <Label text="Title" styleClass="addCommissionWindowLabel">
+                            <Label text="Title" styleClass="addCommissionWindowLabel" minWidth="118" maxWidth="118">
                                 <HBox.margin>
-                                    <Insets top ="10" right="82.0"/>
+                                    <Insets top ="10"/>
                                 </HBox.margin>
                             </Label>
-                            <TextField fx:id="title" styleClass="addCommissionTextField" minWidth="500"/>
+                            <TextField fx:id="title" styleClass="addCommissionTextField" minWidth="500" maxWidth="500"/>
                         </HBox>
 
                         <HBox>
-                            <Label text="Tags" styleClass="addCommissionWindowLabel">
-                                <HBox.margin>
-                                    <Insets right="78.0"/>
-                                </HBox.margin>
-                            </Label>
+                            <Label text="Tags" styleClass="addCommissionWindowLabel" minWidth="118" maxWidth="118"/>
                             <VBox minWidth="500" maxWidth="500">
                                 <ScrollPane maxWidth="500" maxHeight="200" fitToWidth="true" fitToHeight="true">
                                     <FlowPane fx:id="tags" styleClass="commissionTags" />
@@ -76,30 +72,22 @@
 
                         <HBox spacing="36">
                             <HBox>
-                                <Label text="Deadline" styleClass="addCommissionWindowLabel">
-                                    <HBox.margin>
-                                        <Insets right="50.0"/>
-                                    </HBox.margin>
-                                </Label>
-                                <TextField fx:id="deadline" styleClass="addCommissionTextField"/>
+                                <Label text="Deadline" styleClass="addCommissionWindowLabel"
+                                       minWidth="118" maxWidth="118"/>
+                                <TextField fx:id="deadline" styleClass="addCommissionTextField"
+                                           minWidth="200" maxWidth="200"/>
                             </HBox>
 
                             <HBox>
-                                <Label text="Fee" styleClass="addCommissionWindowLabel">
-                                    <HBox.margin>
-                                        <Insets right="20.0"/>
-                                    </HBox.margin>
-                                </Label>
-                                <TextField fx:id="fee" styleClass="addCommissionTextField"/>
+                                <Label text="Fee" styleClass="addCommissionWindowLabel" minWidth="65" maxWidth="65"/>
+                                <TextField fx:id="fee" styleClass="addCommissionTextField"
+                                           minWidth="200" maxWidth="200"/>
                             </HBox>
                         </HBox>
 
                         <HBox>
-                            <Label text="Completion" styleClass="addCommissionWindowLabel">
-                                <HBox.margin>
-                                    <Insets right="36.0"/>
-                                </HBox.margin>
-                            </Label>
+                            <Label text="Completion" styleClass="addCommissionWindowLabel"
+                                   minWidth="118" maxWidth="118"/>
                             <fx:define>
                                 <ToggleGroup fx:id="completion"/>
                             </fx:define>
@@ -110,12 +98,10 @@
                         </HBox>
 
                         <HBox>
-                            <Label text="Description" styleClass="addCommissionWindowLabel">
-                                <HBox.margin>
-                                    <Insets right="32.0"/>
-                                </HBox.margin>
-                            </Label>
-                            <TextField fx:id="description" styleClass="addCommissionTextField" minWidth="500"/>
+                            <Label text="Description" styleClass="addCommissionWindowLabel"
+                                   minWidth="118" maxWidth="118"/>
+                            <TextField fx:id="description" styleClass="addCommissionTextField"
+                                       minWidth="500" maxWidth="500"/>
                         </HBox>
                         <BorderPane.margin>
                             <Insets left="36" right="36"/>

--- a/src/main/resources/view/CommissionWindow.fxml
+++ b/src/main/resources/view/CommissionWindow.fxml
@@ -13,9 +13,10 @@
 <?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.image.Image?>
-
 <?import javafx.scene.control.ToggleButton?>
 <?import javafx.scene.control.ToggleGroup?>
+<?import javafx.scene.layout.Region?>
+
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" resizable="false"
          xmlns:fx="http://javafx.com/fxml/1" width="720" height="500" onCloseRequest="#handleCloseCommissionWindow">
     <icons>
@@ -28,7 +29,7 @@
             </stylesheets>
 
             <ScrollPane maxWidth="720" maxHeight="500" fitToWidth="true" fitToHeight="true"
-                        styleClass="edge-to-edge">
+                        styleClass="edge-to-edge, addWindows">
             <BorderPane fx:id="addCommissionContainer" style="-fx-background-color: #3C424B;">
                 <top>
                     <HBox style="-fx-background-color: #1E2229;">
@@ -45,7 +46,12 @@
                 </top>
                 <center>
                     <VBox spacing="12">
-                        <HBox fx:id="errorMessagePlaceholder" alignment="CENTER"/>
+                        <HBox fx:id="errorMessagePlaceholder" alignment="CENTER_LEFT">
+                            <minHeight>
+                                <!-- Ensures that the label text is never truncated -->
+                                <Region fx:constant="USE_PREF_SIZE" />
+                            </minHeight>
+                        </HBox>
                         <HBox>
                             <Label text="Title" styleClass="addCommissionWindowLabel" minWidth="118" maxWidth="118">
                                 <HBox.margin>

--- a/src/main/resources/view/CustomerWindow.fxml
+++ b/src/main/resources/view/CustomerWindow.fxml
@@ -46,20 +46,17 @@
                     <VBox spacing="12">
                         <HBox fx:id="errorMessagePlaceholder" alignment="CENTER"/>
                         <HBox>
-                            <Label text="Name" styleClass="addCommissionWindowLabel">
+                            <Label text="Name" styleClass="addCommissionWindowLabel" minWidth="118" maxWidth="118">
                                 <HBox.margin>
-                                    <Insets top ="10" right="68.0"/>
+                                    <Insets top="10"/>
                                 </HBox.margin>
                             </Label>
-                            <TextField fx:id="name" styleClass="addCommissionTextField" minWidth="500"/>
+                            <TextField fx:id="name" styleClass="addCommissionTextField"
+                                       minWidth="500" maxWidth="500"/>
                         </HBox>
 
                         <HBox>
-                            <Label text="Tags" styleClass="addCommissionWindowLabel">
-                                <HBox.margin>
-                                    <Insets right="78.0"/>
-                                </HBox.margin>
-                            </Label>
+                            <Label text="Tags" styleClass="addCommissionWindowLabel" minWidth="118" maxWidth="118"/>
                             <VBox minWidth="500" maxWidth="500">
                                 <ScrollPane maxWidth="500" maxHeight="200" fitToWidth="true" fitToHeight="true">
                                     <FlowPane fx:id="tags" styleClass="customerTags"/>
@@ -76,31 +73,25 @@
 
                         <HBox spacing="36">
                             <HBox>
-                                <Label text="Address" styleClass="addCommissionWindowLabel">
-                                    <HBox.margin>
-                                        <Insets right="50.0"/>
-                                    </HBox.margin>
-                                </Label>
-                                <TextField fx:id="address" styleClass="addCommissionTextField"/>
+                                <Label text="Email" styleClass="addCommissionWindowLabel"
+                                       minWidth="118" maxWidth="118"/>
+                                <TextField fx:id="email" styleClass="addCommissionTextField"
+                                           minWidth="200" maxWidth="200"/>
                             </HBox>
 
                             <HBox>
-                                <Label text="Phone" styleClass="addCommissionWindowLabel">
-                                    <HBox.margin>
-                                        <Insets right="20.0"/>
-                                    </HBox.margin>
-                                </Label>
-                                <TextField fx:id="phone" styleClass="addCommissionTextField"/>
+                                <Label text="Phone" styleClass="addCommissionWindowLabel"
+                                       minWidth="65" maxWidth="65"/>
+                                <TextField fx:id="phone" styleClass="addCommissionTextField"
+                                           minWidth="200" maxWidth="200"/>
                             </HBox>
                         </HBox>
 
                         <HBox>
-                            <Label text="Email" styleClass="addCommissionWindowLabel">
-                                <HBox.margin>
-                                    <Insets right="70.0"/>
-                                </HBox.margin>
-                            </Label>
-                            <TextField fx:id="email" styleClass="addCommissionTextField"/>
+                            <Label text="Address" styleClass="addCommissionWindowLabel"
+                                   minWidth="118" maxWidth="118"/>
+                            <TextField fx:id="address" styleClass="addCommissionTextField"
+                                       minWidth="500" maxWidth="500"/>
                         </HBox>
 
                         <BorderPane.margin>

--- a/src/main/resources/view/CustomerWindow.fxml
+++ b/src/main/resources/view/CustomerWindow.fxml
@@ -13,6 +13,7 @@
 <?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.image.Image?>
+<?import javafx.scene.layout.Region?>
 
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" resizable="false"
          xmlns:fx="http://javafx.com/fxml/1" width="720" height="450"
@@ -27,7 +28,7 @@
             </stylesheets>
 
             <ScrollPane maxWidth="720" maxHeight="450" fitToWidth="true" fitToHeight="true"
-                        styleClass="edge-to-edge">
+                        styleClass="edge-to-edge, addWindows">
             <BorderPane fx:id="customerContainer" style="-fx-background-color: #3C424B;">
                 <top>
                     <HBox style="-fx-background-color: #1E2229;">
@@ -44,7 +45,12 @@
                 </top>
                 <center>
                     <VBox spacing="12">
-                        <HBox fx:id="errorMessagePlaceholder" alignment="CENTER"/>
+                        <HBox fx:id="errorMessagePlaceholder" alignment="CENTER_LEFT">
+                            <minHeight>
+                                <!-- Ensures that the label text is never truncated -->
+                                <Region fx:constant="USE_PREF_SIZE" />
+                            </minHeight>
+                        </HBox>
                         <HBox>
                             <Label text="Name" styleClass="addCommissionWindowLabel" minWidth="118" maxWidth="118">
                                 <HBox.margin>

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -449,7 +449,6 @@
 .commandWindowErrorMessage {
     -fx-font-size: 16px;
     -fx-text-fill: #A7BAFF;
-    -fx-text-alignment: center;
     -fx-border-width: 2px;
     -fx-border-radius: 4px;
     -fx-border-color: #A7BAFF;
@@ -555,6 +554,10 @@
 }
 
 .windowScrollPane .viewport {
+    -fx-background-color: #3C424B;
+}
+
+.addWindows {
     -fx-background-color: #3C424B;
 }
 

--- a/src/main/resources/view/IterationWindow.fxml
+++ b/src/main/resources/view/IterationWindow.fxml
@@ -13,8 +13,9 @@
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.image.Image?>
-
 <?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.layout.Region?>
+
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" resizable="false"
          xmlns:fx="http://javafx.com/fxml/1" width="740" height="600"
          onCloseRequest="#handleCloseIterationWindow">
@@ -28,7 +29,7 @@
             </stylesheets>
 
             <ScrollPane maxWidth="720" maxHeight="580" fitToWidth="true" fitToHeight="true"
-                        styleClass="edge-to-edge">
+                        styleClass="edge-to-edge, addWindows">
             <BorderPane fx:id="iterationContainer" style="-fx-background-color: #3C424B;">
                 <top>
                     <HBox style="-fx-background-color: #1E2229;">
@@ -45,7 +46,12 @@
                 </top>
                 <center>
                     <VBox spacing="12">
-                        <HBox fx:id="errorMessagePlaceholder" alignment="CENTER"/>
+                        <HBox fx:id="errorMessagePlaceholder" alignment="CENTER_LEFT">
+                            <minHeight>
+                                <!-- Ensures that the label text is never truncated -->
+                                <Region fx:constant="USE_PREF_SIZE" />
+                            </minHeight>
+                        </HBox>
                         <HBox>
                             <Label text="Date" styleClass="addCommissionWindowLabel" minWidth="118" maxWidth="118">
                                 <HBox.margin>

--- a/src/main/resources/view/IterationWindow.fxml
+++ b/src/main/resources/view/IterationWindow.fxml
@@ -16,7 +16,7 @@
 
 <?import javafx.scene.control.ScrollPane?>
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" resizable="false"
-         xmlns:fx="http://javafx.com/fxml/1" width="720" height="580"
+         xmlns:fx="http://javafx.com/fxml/1" width="740" height="600"
          onCloseRequest="#handleCloseIterationWindow">
     <icons>
         <Image url="@/images/art.png"/>
@@ -47,30 +47,27 @@
                     <VBox spacing="12">
                         <HBox fx:id="errorMessagePlaceholder" alignment="CENTER"/>
                         <HBox>
-                            <Label text="Date" styleClass="addCommissionWindowLabel">
+                            <Label text="Date" styleClass="addCommissionWindowLabel" minWidth="118" maxWidth="118">
                                 <HBox.margin>
-                                    <Insets top ="10" right="85.0"/>
+                                    <Insets top ="10"/>
                                 </HBox.margin>
                             </Label>
-                            <TextField fx:id="date" styleClass="addCommissionTextField" minWidth="500"/>
+                            <TextField fx:id="date" styleClass="addCommissionTextField"
+                                       minWidth="500" maxWidth="500"/>
                         </HBox>
 
                         <HBox>
-                            <Label text="Description" styleClass="addCommissionWindowLabel">
-                                <HBox.margin>
-                                    <Insets right="32.0"/>
-                                </HBox.margin>
-                            </Label>
-                            <TextField fx:id="description" styleClass="addCommissionTextField" minWidth="500"/>
+                            <Label text="Description" styleClass="addCommissionWindowLabel"
+                                   minWidth="118" maxWidth="118"/>
+                            <TextField fx:id="description" styleClass="addCommissionTextField"
+                                       maxWidth="500" minWidth="500"/>
                         </HBox>
 
                         <HBox>
-                            <Label text="Feedback" styleClass="addCommissionWindowLabel">
-                                <HBox.margin>
-                                    <Insets right="48.0"/>
-                                </HBox.margin>
-                            </Label>
-                            <TextField fx:id="feedback" styleClass="addCommissionTextField" minWidth="500"/>
+                            <Label text="Feedback" styleClass="addCommissionWindowLabel"
+                                   minWidth="118" maxWidth="118"/>
+                            <TextField fx:id="feedback" styleClass="addCommissionTextField"
+                                       maxWidth="500" minWidth="500"/>
                         </HBox>
 
                         <HBox spacing="56">


### PR DESCRIPTION
UI should work now on Windows better(?)- not sure why by the GUI was rendering differently in different OS (I'm on mac). Just hardcoded the dimensions explictly to make sure that the fields are where we want them to be (hopefully it'd work).

Also realised the error message for the AddIteration window was a little misleading when no image is selected (says the home directory isn't a file) so I fixed that too.

<table>
<tr>
<th>macOS (before)</th><th>Windows (before)</th>
</tr>
<tr>
<td><img width="750" alt="Screenshot 2022-10-26 at 6 51 01 PM" src="https://user-images.githubusercontent.com/79991214/198009129-0d25ddd8-0268-4ec7-b468-d869e0888371.png"></td>
<td><img width="750" alt="Screenshot 2022-10-26 at 6 51 01 PM" src="https://user-images.githubusercontent.com/79991214/198008916-39ccae0d-4df8-4433-a380-3de95a4cacda.jpg"></td>
</tr>

<tr>
<th>macOS (after)</th><th>Windows (after)</th>
</tr>
<tr>
<td><img width="750" alt="Screenshot 2022-10-26 at 6 51 01 PM" src="https://user-images.githubusercontent.com/79991214/198007844-3fc78659-636c-47eb-91f2-a3e0a5f49765.png"></td>
<td><img width="750" alt="Screenshot 2022-10-26 at 6 51 01 PM" src="https://user-images.githubusercontent.com/79991214/198007884-30bccd64-ca5f-494a-992a-17df380a56e7.jpg"></td>
</tr>
</table>

Can someone help to test this out too to make sure there are no other UI bugs on Windows/ Linux? Thanks!
