### PR TITLE
Stats

### DIFF
--- a/src/main/java/seedu/address/model/commission/UniqueCommissionList.java
+++ b/src/main/java/seedu/address/model/commission/UniqueCommissionList.java
@@ -76,7 +76,7 @@ public class UniqueCommissionList implements Iterable<Commission> {
     }
 
     /**
-     * Returns the number of commissions that are not started.
+     * Returns the number of commissions that are in progress.
      */
     public long getInProgressSize() {
         return internalList.stream()

--- a/src/main/java/seedu/address/model/commission/UniqueCommissionList.java
+++ b/src/main/java/seedu/address/model/commission/UniqueCommissionList.java
@@ -58,11 +58,40 @@ public class UniqueCommissionList implements Iterable<Commission> {
     }
 
     /**
-     * Returns the number of active commissions.
+     * Returns the number of active (in progress and not started) commissions.
      */
     public long getActiveSize() {
         return internalList.stream()
                 .filter(commission -> !commission.getCompletionStatus().isCompleted)
+                .count();
+    }
+
+    /**
+     * Returns the number of commissions that are completed.
+     */
+    public long getCompletedSize() {
+        return internalList.stream()
+                .filter(commission -> commission.getCompletionStatus().isCompleted)
+                .count();
+    }
+
+    /**
+     * Returns the number of commissions that are not started.
+     */
+    public long getInProgressSize() {
+        return internalList.stream()
+                .filter(commission -> commission.getCompletionStatusString()
+                        .equals(Commission.CompletionStatusString.IN_PROGRESS))
+                .count();
+    }
+
+    /**
+     * Returns the number of commissions that are not started.
+     */
+    public long getNotStartedSize() {
+        return internalList.stream()
+                .filter(commission -> commission.getCompletionStatusString()
+                        .equals(Commission.CompletionStatusString.NOT_STARTED))
                 .count();
     }
 

--- a/src/main/java/seedu/address/model/customer/Customer.java
+++ b/src/main/java/seedu/address/model/customer/Customer.java
@@ -90,6 +90,27 @@ public class Customer {
     }
 
     /**
+     * Returns the total number of completed commissions made by this customer.
+     */
+    public long getCompletedCommissionCount() {
+        return commissions.getCompletedSize();
+    }
+
+    /**
+     * Returns the total number of commissions that are in progress made by this customer.
+     */
+    public long getInProgressCommissionCount() {
+        return commissions.getInProgressSize();
+    }
+
+    /**
+     * Returns the total number of commissions that are not started made by this customer.
+     */
+    public long getNotStartedCommissionCount() {
+        return commissions.getNotStartedSize();
+    }
+
+    /**
      * Get last date of customer's commissions.
      */
     public LocalDate getLastDate() {

--- a/src/main/java/seedu/address/ui/CustomerDetailsPane.java
+++ b/src/main/java/seedu/address/ui/CustomerDetailsPane.java
@@ -2,12 +2,15 @@ package seedu.address.ui;
 
 import java.util.Comparator;
 
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.ObservableObject;
+import seedu.address.model.commission.Commission;
 import seedu.address.model.customer.Customer;
 
 /**
@@ -38,6 +41,8 @@ public class CustomerDetailsPane extends UiPart<Region> {
     @FXML
     private Label email;
     @FXML
+    private Label totalRevenue;
+    @FXML
     private FlowPane tags;
 
     /**
@@ -46,10 +51,8 @@ public class CustomerDetailsPane extends UiPart<Region> {
     public CustomerDetailsPane(ObservableObject<Customer> customer) {
         super(FXML);
         this.customer = customer.getValue();
-        this.updateUI(this.customer);
-        customer.addListener((observable, oldValue, newValue) -> {
-            this.updateUI(newValue);
-        });
+        handleCustomerCommissionChanges(this.customer);
+        customer.addListener((observable, oldValue, newValue) -> handleCustomerCommissionChanges(newValue));
     }
 
     private void updateUI(Customer customer) {
@@ -58,17 +61,29 @@ public class CustomerDetailsPane extends UiPart<Region> {
             phone.setText("");
             address.setText("");
             email.setText("");
+            totalRevenue.setText("");
             tags.getChildren().clear();
         } else {
             name.setText(customer.getName().fullName);
             phone.setText(customer.getPhone().value);
             address.setText(customer.getAddress().map(address -> address.value).orElse(""));
             email.setText(customer.getEmail().value);
+            totalRevenue.setText(String.format("%.2f", customer.getRevenue()));
             tags.getChildren().clear();
             customer.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
         }
+    }
+
+    private void handleCustomerCommissionChanges(Customer newValue) {
+        if (newValue != null) {
+            ObservableList<Commission> observableList = newValue.getCommissionList();
+            observableList.addListener((ListChangeListener<Commission>) c -> {
+                updateUI(newValue);
+            });
+        }
+        updateUI(newValue);
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/CustomerDetailsPane.java
+++ b/src/main/java/seedu/address/ui/CustomerDetailsPane.java
@@ -43,6 +43,14 @@ public class CustomerDetailsPane extends UiPart<Region> {
     @FXML
     private Label totalRevenue;
     @FXML
+    private Label commissionCount;
+    @FXML
+    private Label commissionCompletedCount;
+    @FXML
+    private Label commissionInProgressCount;
+    @FXML
+    private Label commissionNotStartedCount;
+    @FXML
     private FlowPane tags;
 
     /**
@@ -62,6 +70,10 @@ public class CustomerDetailsPane extends UiPart<Region> {
             address.setText("");
             email.setText("");
             totalRevenue.setText("");
+            commissionCount.setText("");
+            commissionCompletedCount.setText("");
+            commissionInProgressCount.setText("");
+            commissionNotStartedCount.setText("");
             tags.getChildren().clear();
         } else {
             name.setText(customer.getName().fullName);
@@ -69,6 +81,10 @@ public class CustomerDetailsPane extends UiPart<Region> {
             address.setText(customer.getAddress().map(address -> address.value).orElse(""));
             email.setText(customer.getEmail().value);
             totalRevenue.setText(String.format("%.2f", customer.getRevenue()));
+            commissionCount.setText(Long.toString(customer.getCommissionCount()));
+            commissionCompletedCount.setText(Long.toString(customer.getCompletedCommissionCount()));
+            commissionInProgressCount.setText(Long.toString(customer.getInProgressCommissionCount()));
+            commissionNotStartedCount.setText(Long.toString(customer.getNotStartedCommissionCount()));
             tags.getChildren().clear();
             customer.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))

--- a/src/main/java/seedu/address/ui/CustomerDetailsPane.java
+++ b/src/main/java/seedu/address/ui/CustomerDetailsPane.java
@@ -2,9 +2,11 @@ package seedu.address.ui;
 
 import java.util.Comparator;
 
+import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
+import javafx.scene.chart.PieChart;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
@@ -56,6 +58,8 @@ public class CustomerDetailsPane extends UiPart<Region> {
     private Label commissionLabel;
     @FXML
     private FlowPane tags;
+    @FXML
+    private HBox pieChartPlaceholder;
 
     /**
      * Creates a {@code CustomerCode} with the given {@code Customer} and index to display.
@@ -80,6 +84,7 @@ public class CustomerDetailsPane extends UiPart<Region> {
             commissionInProgressCount.setText("");
             commissionNotStartedCount.setText("");
             tags.getChildren().clear();
+            pieChartPlaceholder.getChildren().clear();
         } else {
             name.setText(customer.getName().fullName);
             phone.setText(customer.getPhone().value);
@@ -89,9 +94,32 @@ public class CustomerDetailsPane extends UiPart<Region> {
             commissionLabel.setText(customer.getCommissionCount() == 1
                     ? COMMISSION_LABEL_SINGULAR : COMMISSION_LABEL_PLURAL);
             commissionCount.setText(Long.toString(customer.getCommissionCount()));
+
             commissionCompletedCount.setText(Long.toString(customer.getCompletedCommissionCount()));
             commissionInProgressCount.setText(Long.toString(customer.getInProgressCommissionCount()));
             commissionNotStartedCount.setText(Long.toString(customer.getNotStartedCommissionCount()));
+
+            if (customer.getCommissionCount() > 0) {
+                PieChart.Data completed = new PieChart.Data("Completed", customer.getCompletedCommissionCount());
+                PieChart.Data inProgress = new PieChart.Data("In Progress", customer.getInProgressCommissionCount());
+                PieChart.Data notStarted = new PieChart.Data("Not Started", customer.getNotStartedCommissionCount());
+                ObservableList<PieChart.Data> pieChartData = FXCollections.observableArrayList(
+                        completed, inProgress, notStarted);
+                PieChart pieChart = new PieChart(pieChartData);
+                pieChart.setLabelsVisible(false);
+                pieChart.setStyle("-fx-background-insets: 0; -fx-border-width: 0;");
+                pieChart.setMinWidth(150);
+                pieChart.setMaxWidth(150);
+                pieChart.setMinHeight(150);
+                pieChart.setMaxHeight(150);
+                pieChartPlaceholder.getChildren().setAll(pieChart);
+                completed.getNode().setStyle("-fx-background-insets: 0; -fx-border-width: 0; -fx-pie-color: " + "#32AE46");
+                inProgress.getNode().setStyle("-fx-background-insets: 0; -fx-border-width: 0; -fx-pie-color: " + "#548DE1");
+                notStarted.getNode().setStyle("-fx-background-insets: 0; -fx-border-width: 0; -fx-pie-color: " + "#9DA0A5");
+            } else {
+                pieChartPlaceholder.getChildren().clear();
+            }
+
             tags.getChildren().clear();
             customer.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))

--- a/src/main/java/seedu/address/ui/CustomerDetailsPane.java
+++ b/src/main/java/seedu/address/ui/CustomerDetailsPane.java
@@ -16,13 +16,18 @@ import seedu.address.model.commission.Commission;
 import seedu.address.model.customer.Customer;
 
 /**
- * An UI component that displays information of a {@code Customer}.
+ * A UI component that displays information of a {@code Customer}.
  */
 public class CustomerDetailsPane extends UiPart<Region> {
 
     private static final String FXML = "CustomerDetailsPane.fxml";
     private static final String COMMISSION_LABEL_PLURAL = "Commissions";
     private static final String COMMISSION_LABEL_SINGULAR = "Commission";
+    private static final String PIE_CHART_DATA_STYLE =
+            "-fx-background-insets: 0; -fx-border-width: 0; -fx-pie-color: ";
+    private static final String PIE_CHART_DATA_COMPLETED_BACKGROUND_COLOR = "#32AE46";
+    private static final String PIE_CHART_DATA_IN_PROGRESS_BACKGROUND_COLOR = "#548DE1";
+    private static final String PIE_CHART_DATA_NOT_STARTED_BACKGROUND_COLOR = "#9DA0A5";
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
@@ -33,6 +38,7 @@ public class CustomerDetailsPane extends UiPart<Region> {
      */
 
     private final Customer customer;
+    private final PieChart pieChart;
 
     @FXML
     private HBox detailsPane;
@@ -67,64 +73,118 @@ public class CustomerDetailsPane extends UiPart<Region> {
     public CustomerDetailsPane(ObservableObject<Customer> customer) {
         super(FXML);
         this.customer = customer.getValue();
+        pieChart = instantiatePieChart();
         handleCustomerCommissionChanges(this.customer);
         customer.addListener((observable, oldValue, newValue) -> handleCustomerCommissionChanges(newValue));
     }
 
     private void updateUI(Customer customer) {
         if (customer == null) {
-            name.setText("No customer selected");
-            phone.setText("");
-            address.setText("");
-            email.setText("");
-            totalRevenue.setText("");
-            commissionLabel.setText(COMMISSION_LABEL_PLURAL); // 0 commissions
-            commissionCount.setText("");
-            commissionCompletedCount.setText("");
-            commissionInProgressCount.setText("");
-            commissionNotStartedCount.setText("");
-            tags.getChildren().clear();
-            pieChartPlaceholder.getChildren().clear();
+            clearAllUiFields();
         } else {
-            name.setText(customer.getName().fullName);
-            phone.setText(customer.getPhone().value);
-            address.setText(customer.getAddress().map(address -> address.value).orElse(""));
-            email.setText(customer.getEmail().value);
-            totalRevenue.setText(String.format("$%.2f", customer.getRevenue()));
-            commissionLabel.setText(customer.getCommissionCount() == 1
-                    ? COMMISSION_LABEL_SINGULAR : COMMISSION_LABEL_PLURAL);
-            commissionCount.setText(Long.toString(customer.getCommissionCount()));
+            setCustomerUiFields(customer);
+            setCommissionStatUi(customer);
+        }
+    }
 
-            commissionCompletedCount.setText(Long.toString(customer.getCompletedCommissionCount()));
-            commissionInProgressCount.setText(Long.toString(customer.getInProgressCommissionCount()));
-            commissionNotStartedCount.setText(Long.toString(customer.getNotStartedCommissionCount()));
+    /**
+     * Creates a pie chart with the styling.
+     */
+    private PieChart instantiatePieChart() {
+        PieChart pieChart = new PieChart();
+        pieChart.setLabelsVisible(false);
+        pieChart.getStyleClass().add("commissionPieChart");
+        pieChart.setMinWidth(150);
+        pieChart.setMaxWidth(150);
+        pieChart.setMinHeight(150);
+        pieChart.setMaxHeight(150);
+        pieChart.setAnimated(true);
+        return pieChart;
+    }
 
-            if (customer.getCommissionCount() > 0) {
-                PieChart.Data completed = new PieChart.Data("Completed", customer.getCompletedCommissionCount());
-                PieChart.Data inProgress = new PieChart.Data("In Progress", customer.getInProgressCommissionCount());
-                PieChart.Data notStarted = new PieChart.Data("Not Started", customer.getNotStartedCommissionCount());
-                ObservableList<PieChart.Data> pieChartData = FXCollections.observableArrayList(
-                        completed, inProgress, notStarted);
-                PieChart pieChart = new PieChart(pieChartData);
-                pieChart.setLabelsVisible(false);
-                pieChart.setStyle("-fx-background-insets: 0; -fx-border-width: 0;");
-                pieChart.setMinWidth(150);
-                pieChart.setMaxWidth(150);
-                pieChart.setMinHeight(150);
-                pieChart.setMaxHeight(150);
-                pieChartPlaceholder.getChildren().setAll(pieChart);
-                completed.getNode().setStyle("-fx-background-insets: 0; -fx-border-width: 0; -fx-pie-color: " + "#32AE46");
-                inProgress.getNode().setStyle("-fx-background-insets: 0; -fx-border-width: 0; -fx-pie-color: " + "#548DE1");
-                notStarted.getNode().setStyle("-fx-background-insets: 0; -fx-border-width: 0; -fx-pie-color: " + "#9DA0A5");
-            } else {
-                pieChartPlaceholder.getChildren().clear();
-            }
+    /**
+     * Resets the CustomerDetailsPane UI to an 'empty state'.
+     */
+    private void clearAllUiFields() {
+        name.setText("No customer selected");
+        phone.setText("");
+        address.setText("");
+        email.setText("");
+        totalRevenue.setText("");
+        commissionLabel.setText("");
+        commissionCount.setText("");
+        commissionCompletedCount.setText("");
+        commissionInProgressCount.setText("");
+        commissionNotStartedCount.setText("");
+        tags.getChildren().clear();
+        pieChartPlaceholder.getChildren().clear();
+    }
 
-            tags.getChildren().clear();
-            customer.getTags().stream()
+    /**
+     * Sets the CustomerDetailsPane UI customer fields to the attributes
+     * of the specified customer (name, phone, address, email, tags and total revenue).
+     */
+    private void setCustomerUiFields(Customer customer) {
+        name.setText(customer.getName().fullName);
+        phone.setText(customer.getPhone().value);
+        address.setText(customer.getAddress().map(address -> address.value).orElse(""));
+        email.setText(customer.getEmail().value);
+        tags.getChildren().clear();
+        customer.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+        totalRevenue.setText(String.format("$%.2f", customer.getRevenue()));
+    }
+
+    /**
+     * Updates the CustomerDetailsPane UI with commission statistics.
+     */
+    private void setCommissionStatUi(Customer customer) {
+        long totalCommissionCount = customer.getCommissionCount();
+        long completedCommissionCount = customer.getCompletedCommissionCount();
+        long inProgressCommissionCount = customer.getInProgressCommissionCount();
+        long notStartedCommissionCount = customer.getNotStartedCommissionCount();
+
+        // set the field label to be grammatically correct
+        commissionLabel.setText(totalCommissionCount == 1 ? COMMISSION_LABEL_SINGULAR : COMMISSION_LABEL_PLURAL);
+
+        // sets the commission count fields
+        commissionCount.setText(Long.toString(totalCommissionCount));
+        commissionCompletedCount.setText(Long.toString(completedCommissionCount));
+        commissionInProgressCount.setText(Long.toString(inProgressCommissionCount));
+        commissionNotStartedCount.setText(Long.toString(notStartedCommissionCount));
+
+        // generates the pie chart
+        if (totalCommissionCount > 0) {
+            generateCommissionPieChart(completedCommissionCount, inProgressCommissionCount, notStartedCommissionCount);
+        } else {
+            pieChartPlaceholder.getChildren().clear();
         }
+    }
+
+    /**
+     * Handles the generation of the pie chart statistic.
+     */
+    private void generateCommissionPieChart(long completedCommissionCount,
+                                            long inProgressCommissionCount, long notStartedCommissionCount) {
+        // creates the pie chart segments and the pie chart
+        PieChart.Data completed = new PieChart.Data(Commission.CompletionStatusString.COMPLETED.toString(),
+                completedCommissionCount);
+        PieChart.Data inProgress = new PieChart.Data(Commission.CompletionStatusString.IN_PROGRESS.toString(),
+                inProgressCommissionCount);
+        PieChart.Data notStarted = new PieChart.Data(Commission.CompletionStatusString.NOT_STARTED.toString(),
+                notStartedCommissionCount);
+        ObservableList<PieChart.Data> pieChartData =
+                FXCollections.observableArrayList(completed, inProgress, notStarted);
+        pieChart.setData(pieChartData);
+
+        // styles each of the pie chart segment
+        completed.getNode().setStyle(PIE_CHART_DATA_STYLE + PIE_CHART_DATA_COMPLETED_BACKGROUND_COLOR);
+        inProgress.getNode().setStyle(PIE_CHART_DATA_STYLE + PIE_CHART_DATA_IN_PROGRESS_BACKGROUND_COLOR);
+        notStarted.getNode().setStyle(PIE_CHART_DATA_STYLE + PIE_CHART_DATA_NOT_STARTED_BACKGROUND_COLOR);
+
+        // set the placeholder to the generated pie chart
+        pieChartPlaceholder.getChildren().setAll(pieChart);
     }
 
     private void handleCustomerCommissionChanges(Customer newValue) {

--- a/src/main/java/seedu/address/ui/CustomerDetailsPane.java
+++ b/src/main/java/seedu/address/ui/CustomerDetailsPane.java
@@ -19,6 +19,8 @@ import seedu.address.model.customer.Customer;
 public class CustomerDetailsPane extends UiPart<Region> {
 
     private static final String FXML = "CustomerDetailsPane.fxml";
+    private static final String COMMISSION_LABEL_PLURAL = "Commissions";
+    private static final String COMMISSION_LABEL_SINGULAR = "Commission";
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
@@ -51,6 +53,8 @@ public class CustomerDetailsPane extends UiPart<Region> {
     @FXML
     private Label commissionNotStartedCount;
     @FXML
+    private Label commissionLabel;
+    @FXML
     private FlowPane tags;
 
     /**
@@ -70,6 +74,7 @@ public class CustomerDetailsPane extends UiPart<Region> {
             address.setText("");
             email.setText("");
             totalRevenue.setText("");
+            commissionLabel.setText(COMMISSION_LABEL_PLURAL); // 0 commissions
             commissionCount.setText("");
             commissionCompletedCount.setText("");
             commissionInProgressCount.setText("");
@@ -80,7 +85,9 @@ public class CustomerDetailsPane extends UiPart<Region> {
             phone.setText(customer.getPhone().value);
             address.setText(customer.getAddress().map(address -> address.value).orElse(""));
             email.setText(customer.getEmail().value);
-            totalRevenue.setText(String.format("%.2f", customer.getRevenue()));
+            totalRevenue.setText(String.format("$%.2f", customer.getRevenue()));
+            commissionLabel.setText(customer.getCommissionCount() == 1
+                    ? COMMISSION_LABEL_SINGULAR : COMMISSION_LABEL_PLURAL);
             commissionCount.setText(Long.toString(customer.getCommissionCount()));
             commissionCompletedCount.setText(Long.toString(customer.getCompletedCommissionCount()));
             commissionInProgressCount.setText(Long.toString(customer.getInProgressCommissionCount()));

--- a/src/main/java/seedu/address/ui/CustomerDetailsPane.java
+++ b/src/main/java/seedu/address/ui/CustomerDetailsPane.java
@@ -8,6 +8,7 @@ import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.chart.PieChart;
 import javafx.scene.control.Label;
+import javafx.scene.control.Tooltip;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
@@ -182,6 +183,10 @@ public class CustomerDetailsPane extends UiPart<Region> {
         completed.getNode().setStyle(PIE_CHART_DATA_STYLE + PIE_CHART_DATA_COMPLETED_BACKGROUND_COLOR);
         inProgress.getNode().setStyle(PIE_CHART_DATA_STYLE + PIE_CHART_DATA_IN_PROGRESS_BACKGROUND_COLOR);
         notStarted.getNode().setStyle(PIE_CHART_DATA_STYLE + PIE_CHART_DATA_NOT_STARTED_BACKGROUND_COLOR);
+
+        for (PieChart.Data data : pieChartData) {
+            Tooltip.install(data.getNode(), new Tooltip(data.getName()));
+        }
 
         // set the placeholder to the generated pie chart
         pieChartPlaceholder.getChildren().setAll(pieChart);

--- a/src/main/java/seedu/address/ui/CustomerDetailsPane.java
+++ b/src/main/java/seedu/address/ui/CustomerDetailsPane.java
@@ -15,6 +15,7 @@ import javafx.scene.layout.Region;
 import seedu.address.commons.core.ObservableObject;
 import seedu.address.model.commission.Commission;
 import seedu.address.model.customer.Customer;
+import seedu.address.model.iteration.Iteration;
 
 /**
  * A UI component that displays information of a {@code Customer}.
@@ -194,9 +195,16 @@ public class CustomerDetailsPane extends UiPart<Region> {
 
     private void handleCustomerCommissionChanges(Customer newValue) {
         if (newValue != null) {
-            ObservableList<Commission> observableList = newValue.getCommissionList();
-            observableList.addListener((ListChangeListener<Commission>) c -> {
+            ObservableList<Commission> observableCommissionList = newValue.getCommissionList();
+
+            observableCommissionList.addListener((ListChangeListener<Commission>) c -> {
                 updateUI(newValue);
+            });
+
+            observableCommissionList.forEach(commission -> {
+                commission.getIterationList().addListener((ListChangeListener<Iteration>) c -> {
+                    updateUI(newValue);
+                });
             });
         }
         updateUI(newValue);

--- a/src/main/resources/view/CommissionDetailsPane.fxml
+++ b/src/main/resources/view/CommissionDetailsPane.fxml
@@ -88,7 +88,7 @@
                 </Label>
                 <HBox id="descriptionField">
                     <Label fx:id="description" text="\$description" wrapText="true"
-                           HBox.hgrow="ALWAYS" minWidth="300" VBox.vgrow="ALWAYS" prefWidth="0">
+                           HBox.hgrow="ALWAYS" minWidth="300" VBox.vgrow="ALWAYS">
                         <minHeight>
                             <!-- Ensures that the label text is never truncated -->
                             <Region fx:constant="USE_PREF_SIZE" />

--- a/src/main/resources/view/CustomerDetailsPane.fxml
+++ b/src/main/resources/view/CustomerDetailsPane.fxml
@@ -2,21 +2,22 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
-<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.control.ScrollPane?>
 
-<HBox id="detailsPane" fx:id="detailsPane" prefHeight="271.0" prefWidth="278.0" xmlns="http://javafx.com/javafx/11"
+<HBox id="detailsPane" fx:id="detailsPane" xmlns="http://javafx.com/javafx/11"
       xmlns:fx="http://javafx.com/fxml/1">
-    <GridPane HBox.hgrow="ALWAYS">
-        <columnConstraints>
-            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150"/>
-        </columnConstraints>
-        <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0" HBox.hgrow="ALWAYS">
+    <AnchorPane minHeight="0.0" minWidth="340.0" HBox.hgrow="ALWAYS">
+    <ScrollPane fitToHeight="true" fitToWidth="true" styleClass="edge-to-edge"
+                AnchorPane.bottomAnchor="0.0"
+                AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0"
+                AnchorPane.topAnchor="0.0">
+        <VBox alignment="CENTER_LEFT" GridPane.columnIndex="0" HBox.hgrow="ALWAYS">
             <padding>
                 <Insets bottom="5" left="15" right="15" top="5"/>
             </padding>
@@ -156,8 +157,6 @@
                 </VBox>
             </GridPane>
         </VBox>
-        <rowConstraints>
-            <RowConstraints/>
-        </rowConstraints>
-    </GridPane>
+    </ScrollPane>
+    </AnchorPane>
 </HBox>

--- a/src/main/resources/view/CustomerDetailsPane.fxml
+++ b/src/main/resources/view/CustomerDetailsPane.fxml
@@ -69,6 +69,16 @@
                     <Insets bottom="4.0" />
                 </VBox.margin>
             </Label>
+
+            <Label fx:id="totalRevenue" styleClass="cell_small_label" text="\$totalrevenue">
+                <minHeight>
+                    <!-- Ensures that the label text is never truncated -->
+                    <Region fx:constant="USE_PREF_SIZE"/>
+                </minHeight>
+                <VBox.margin>
+                    <Insets bottom="4.0" />
+                </VBox.margin>
+            </Label>
         </VBox>
         <rowConstraints>
             <RowConstraints/>

--- a/src/main/resources/view/CustomerDetailsPane.fxml
+++ b/src/main/resources/view/CustomerDetailsPane.fxml
@@ -95,15 +95,7 @@
                 <HBox GridPane.columnIndex="0" GridPane.rowIndex="1" GridPane.columnSpan="3" spacing="8">
                     <VBox spacing="12" minWidth="100" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS"
                           id="commissionCountCard" alignment="CENTER_LEFT" HBox.hgrow="ALWAYS">
-                        <Label fx:id="commissionCount" id="commissionCount" text="\$commissionCount">
-                            <minHeight>
-                                <!-- Ensures that the label text is never truncated -->
-                                <Region fx:constant="USE_PREF_SIZE"/>
-                            </minHeight>
-                            <VBox.margin>
-                                <Insets bottom="4.0" />
-                            </VBox.margin>
-                        </Label>
+                        <Label fx:id="commissionCount" id="commissionCount" text="\$commissionCount"/>
                         <Label fx:id="commissionLabel" text="Commissions" minHeight="26"/>
                     </VBox>
 

--- a/src/main/resources/view/CustomerDetailsPane.fxml
+++ b/src/main/resources/view/CustomerDetailsPane.fxml
@@ -79,6 +79,46 @@
                     <Insets bottom="4.0" />
                 </VBox.margin>
             </Label>
+
+            <Label fx:id="commissionCount" styleClass="cell_small_label" text="\$commissionCount">
+                <minHeight>
+                    <!-- Ensures that the label text is never truncated -->
+                    <Region fx:constant="USE_PREF_SIZE"/>
+                </minHeight>
+                <VBox.margin>
+                    <Insets bottom="4.0" />
+                </VBox.margin>
+            </Label>
+
+            <Label fx:id="commissionCompletedCount" styleClass="cell_small_label" text="\$commissionCompleteCount">
+                <minHeight>
+                    <!-- Ensures that the label text is never truncated -->
+                    <Region fx:constant="USE_PREF_SIZE"/>
+                </minHeight>
+                <VBox.margin>
+                    <Insets bottom="4.0" />
+                </VBox.margin>
+            </Label>
+
+            <Label fx:id="commissionInProgressCount" styleClass="cell_small_label" text="\$commissionInProgressCount">
+                <minHeight>
+                    <!-- Ensures that the label text is never truncated -->
+                    <Region fx:constant="USE_PREF_SIZE"/>
+                </minHeight>
+                <VBox.margin>
+                    <Insets bottom="4.0" />
+                </VBox.margin>
+            </Label>
+
+            <Label fx:id="commissionNotStartedCount" styleClass="cell_small_label" text="\$commissionNotStartedCount">
+                <minHeight>
+                    <!-- Ensures that the label text is never truncated -->
+                    <Region fx:constant="USE_PREF_SIZE"/>
+                </minHeight>
+                <VBox.margin>
+                    <Insets bottom="4.0" />
+                </VBox.margin>
+            </Label>
         </VBox>
         <rowConstraints>
             <RowConstraints/>

--- a/src/main/resources/view/CustomerDetailsPane.fxml
+++ b/src/main/resources/view/CustomerDetailsPane.fxml
@@ -70,55 +70,91 @@
                 </VBox.margin>
             </Label>
 
-            <Label fx:id="totalRevenue" styleClass="cell_small_label" text="\$totalrevenue">
-                <minHeight>
-                    <!-- Ensures that the label text is never truncated -->
-                    <Region fx:constant="USE_PREF_SIZE"/>
-                </minHeight>
+            <Label styleClass="cell_h2_label" text="Insights">
                 <VBox.margin>
-                    <Insets bottom="4.0" />
+                    <Insets top="16" bottom="16"/>
                 </VBox.margin>
             </Label>
 
-            <Label fx:id="commissionCount" styleClass="cell_small_label" text="\$commissionCount">
-                <minHeight>
-                    <!-- Ensures that the label text is never truncated -->
-                    <Region fx:constant="USE_PREF_SIZE"/>
-                </minHeight>
-                <VBox.margin>
-                    <Insets bottom="4.0" />
-                </VBox.margin>
-            </Label>
+            <GridPane vgap="16" hgap="16">
+                <VBox GridPane.columnIndex="0" GridPane.rowIndex="0" GridPane.columnSpan="3"
+                      minWidth="250" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS" id="revenueCard">
+                    <Label fx:id="totalRevenue" id="revenueGenerated" text="\$totalrevenue">
+                        <minHeight>
+                            <!-- Ensures that the label text is never truncated -->
+                            <Region fx:constant="USE_PREF_SIZE"/>
+                        </minHeight>
+                        <VBox.margin>
+                            <Insets bottom="4.0" />
+                        </VBox.margin>
+                    </Label>
+                    <Label text="Total revenue generated"/>
+                </VBox>
 
-            <Label fx:id="commissionCompletedCount" styleClass="cell_small_label" text="\$commissionCompleteCount">
-                <minHeight>
-                    <!-- Ensures that the label text is never truncated -->
-                    <Region fx:constant="USE_PREF_SIZE"/>
-                </minHeight>
-                <VBox.margin>
-                    <Insets bottom="4.0" />
-                </VBox.margin>
-            </Label>
+                <HBox GridPane.columnIndex="0" GridPane.rowIndex="1" GridPane.columnSpan="3" spacing="12"
+                      minWidth="83.3" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS" id="commissionCountCard"
+                      alignment="CENTER_LEFT">
+                    <Label fx:id="commissionCount" id="commissionCount" text="\$commissionCount">
+                        <minHeight>
+                            <!-- Ensures that the label text is never truncated -->
+                            <Region fx:constant="USE_PREF_SIZE"/>
+                        </minHeight>
+                        <VBox.margin>
+                            <Insets bottom="4.0" />
+                        </VBox.margin>
+                    </Label>
+                    <Label fx:id="commissionLabel" text="Commissions" minHeight="26"
+                           style="-fx-text-alignment: bottom;"/>
+                </HBox>
 
-            <Label fx:id="commissionInProgressCount" styleClass="cell_small_label" text="\$commissionInProgressCount">
-                <minHeight>
-                    <!-- Ensures that the label text is never truncated -->
-                    <Region fx:constant="USE_PREF_SIZE"/>
-                </minHeight>
-                <VBox.margin>
-                    <Insets bottom="4.0" />
-                </VBox.margin>
-            </Label>
+                <VBox GridPane.columnIndex="0" GridPane.rowIndex="2" GridPane.columnSpan="1"
+                      minWidth="83.3" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS"
+                      styleClass="commissionBreakdownCountCard" alignment="CENTER">
+                    <Label fx:id="commissionCompletedCount" id="commissionCompletedCount" alignment="CENTER"
+                           text="\$commissionCompleteCount" HBox.hgrow="ALWAYS" minWidth="92.6">
+                        <minHeight>
+                            <!-- Ensures that the label text is never truncated -->
+                            <Region fx:constant="USE_PREF_SIZE"/>
+                        </minHeight>
+                        <VBox.margin>
+                            <Insets bottom="4.0" />
+                        </VBox.margin>
+                    </Label>
+                    <Label text="Completed" HBox.hgrow="ALWAYS" alignment="CENTER"/>
+                </VBox>
 
-            <Label fx:id="commissionNotStartedCount" styleClass="cell_small_label" text="\$commissionNotStartedCount">
-                <minHeight>
-                    <!-- Ensures that the label text is never truncated -->
-                    <Region fx:constant="USE_PREF_SIZE"/>
-                </minHeight>
-                <VBox.margin>
-                    <Insets bottom="4.0" />
-                </VBox.margin>
-            </Label>
+                <VBox GridPane.columnIndex="1" GridPane.rowIndex="2" GridPane.columnSpan="1"
+                      minWidth="83.3" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS"
+                      styleClass="commissionBreakdownCountCard" alignment="CENTER">
+                <Label fx:id="commissionInProgressCount" id="commissionInProgressCount" alignment="CENTER"
+                       text="\$commissionInProgressCount" HBox.hgrow="ALWAYS" minWidth="92.6">
+                        <minHeight>
+                            <!-- Ensures that the label text is never truncated -->
+                            <Region fx:constant="USE_PREF_SIZE"/>
+                        </minHeight>
+                        <VBox.margin>
+                            <Insets bottom="4.0" />
+                        </VBox.margin>
+                    </Label>
+                    <Label text="In Progress" HBox.hgrow="ALWAYS" alignment="CENTER"/>
+                </VBox>
+
+                <VBox GridPane.columnIndex="2" GridPane.rowIndex="2" GridPane.columnSpan="1"
+                      minWidth="92.6" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS"
+                      styleClass="commissionBreakdownCountCard" alignment="CENTER">
+                    <Label fx:id="commissionNotStartedCount" id="commissionNotStartedCount"
+                           text="\$commissionNotStartedCount" alignment="CENTER" minWidth="92.6">
+                        <minHeight>
+                            <!-- Ensures that the label text is never truncated -->
+                            <Region fx:constant="USE_PREF_SIZE"/>
+                        </minHeight>
+                        <VBox.margin>
+                            <Insets bottom="4.0" />
+                        </VBox.margin>
+                    </Label>
+                    <Label text="Not Started" HBox.hgrow="ALWAYS" alignment="CENTER"/>
+                </VBox>
+            </GridPane>
         </VBox>
         <rowConstraints>
             <RowConstraints/>

--- a/src/main/resources/view/CustomerDetailsPane.fxml
+++ b/src/main/resources/view/CustomerDetailsPane.fxml
@@ -92,20 +92,23 @@
                     <Label text="Total revenue generated"/>
                 </VBox>
 
-                <HBox GridPane.columnIndex="0" GridPane.rowIndex="1" GridPane.columnSpan="3" spacing="12"
-                      minWidth="83.3" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS" id="commissionCountCard"
-                      alignment="CENTER_LEFT">
-                    <Label fx:id="commissionCount" id="commissionCount" text="\$commissionCount">
-                        <minHeight>
-                            <!-- Ensures that the label text is never truncated -->
-                            <Region fx:constant="USE_PREF_SIZE"/>
-                        </minHeight>
-                        <VBox.margin>
-                            <Insets bottom="4.0" />
-                        </VBox.margin>
-                    </Label>
-                    <Label fx:id="commissionLabel" text="Commissions" minHeight="26"
-                           style="-fx-text-alignment: bottom;"/>
+                <HBox GridPane.columnIndex="0" GridPane.rowIndex="1" GridPane.columnSpan="3" spacing="8">
+                    <VBox spacing="12" minWidth="100" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS"
+                          id="commissionCountCard" alignment="CENTER_LEFT" HBox.hgrow="ALWAYS">
+                        <Label fx:id="commissionCount" id="commissionCount" text="\$commissionCount">
+                            <minHeight>
+                                <!-- Ensures that the label text is never truncated -->
+                                <Region fx:constant="USE_PREF_SIZE"/>
+                            </minHeight>
+                            <VBox.margin>
+                                <Insets bottom="4.0" />
+                            </VBox.margin>
+                        </Label>
+                        <Label fx:id="commissionLabel" text="Commissions" minHeight="26"/>
+                    </VBox>
+
+                    <HBox fx:id="pieChartPlaceholder"
+                          minWidth="150" maxWidth="150" minHeight="150" maxHeight="150" HBox.hgrow="NEVER"/>
                 </HBox>
 
                 <VBox GridPane.columnIndex="0" GridPane.rowIndex="2" GridPane.columnSpan="1"

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -619,3 +619,42 @@
     -fx-background-radius: 4px;
     -fx-padding: 16px;
 }
+
+#revenueCard, #commissionCountCard, .commissionBreakdownCountCard {
+    -fx-padding: 16px;
+    -fx-background-color: #23272F;
+    -fx-background-radius: 16px;
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.25), 4, 0, 0, 4);
+}
+
+#revenueCard .label, #commissionCountCard .label, .commissionBreakdownCountCard .label {
+    -fx-text-fill: #D9D9D9;
+    -fx-font-family: "Arial";
+}
+
+#revenueGenerated {
+    -fx-font-size: 32px;
+    -fx-font-weight: bold;
+}
+
+#commissionCount {
+    -fx-font-size: 28px;
+    -fx-font-weight: bold;
+}
+
+#commissionCompletedCount, #commissionInProgressCount, #commissionNotStartedCount {
+    -fx-font-size: 24px;
+    -fx-font-weight: bold;
+}
+
+#commissionCompletedCount {
+    -fx-text-fill: #32AE46;
+}
+
+#commissionInProgressCount {
+    -fx-text-fill: #548DE1;
+}
+
+#commissionNotStartedCount {
+    -fx-text-fill: #9DA0A5;
+}

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -561,6 +561,12 @@
     -fx-background-color: #3C424B;
 }
 
+.commissionPieChart {
+    -fx-background-insets: 0;
+    -fx-border-width: 0;
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.25), 4, 0, 4, 8);
+}
+
 #iterationListView.list-view {
     -fx-padding: 0px;
     -fx-background-color: #15181F;


### PR DESCRIPTION
<h1>"stats"!!! 📊 </h1>

Shows total revenue, commission count and breakdown + a pie chart showing the breakdown of completion statuses. This pie chart will not be shown if there are no commissions.

⚠️ **Warning:** I still don't really understand how listeners work, but it **seems** to be listening correctly to its commissions and iterations. Also, the current implementation definitely has a non-ideal run time (iterating through all commissions and for each commission, their iterations to attach a listener), but I'm not sure if this is unavoidable. There doesn't seem to be any noticable lag even when adding a large(r) number of commissions, so hopefully that's ok.
<br>
<img width="1440" alt="Screenshot 2022-10-28 at 12 09 58 AM" src="https://user-images.githubusercontent.com/79991214/198342649-97e3b26d-9eea-462b-b371-e1a9a926bbec.png">

<img width="1440" alt="Screenshot 2022-10-28 at 12 11 52 AM" src="https://user-images.githubusercontent.com/79991214/198343009-0fd6690e-ece7-4dd6-9725-c7f661be9558.png">
