### PR TITLE
Fix unclear opencus opencom prompt

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -33,7 +33,5 @@ public class Messages {
 
 
     public static final String MESSAGE_OPEN_CUSTOMER_SUCCESS = "Opened Customer: %1$s";
-    public static final String MESSAGE_OPEN_CUSTOMER_TAB_SUCCESS = "Opened Customer tab";
-    public static final String MESSAGE_OPEN_COMMISSION_TAB_SUCCESS = "Opened Commission Tab";
     public static final String MESSAGE_OPEN_COMMISSION_SUCCESS = "Opened Commission: %1$s";
 }

--- a/src/main/java/seedu/address/logic/commands/OpenCommissionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/OpenCommissionCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_OPEN_COMMISSION_SUCCESS;
-import static seedu.address.commons.core.Messages.MESSAGE_OPEN_COMMISSION_TAB_SUCCESS;
 
 import java.util.List;
 import java.util.Objects;
@@ -47,7 +46,7 @@ public class OpenCommissionCommand extends Command {
         model.selectTab(GuiTab.COMMISSION);
 
         if (targetIndex == null) {
-            return new CommandResult(MESSAGE_OPEN_COMMISSION_TAB_SUCCESS);
+            return new CommandResult(MESSAGE_USAGE);
         }
 
         List<Commission> lastShownList = model.getFilteredCommissionList();

--- a/src/main/java/seedu/address/logic/commands/OpenCustomerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/OpenCustomerCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_OPEN_CUSTOMER_SUCCESS;
-import static seedu.address.commons.core.Messages.MESSAGE_OPEN_CUSTOMER_TAB_SUCCESS;
 
 import java.util.List;
 import java.util.Objects;
@@ -44,7 +43,7 @@ public class OpenCustomerCommand extends Command {
         model.selectTab(GuiTab.CUSTOMER);
         List<Customer> lastShownList = model.getSortedFilteredCustomerList();
         if (targetIndex == null) {
-            return new CommandResult(MESSAGE_OPEN_CUSTOMER_TAB_SUCCESS);
+            return new CommandResult(MESSAGE_USAGE);
         }
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {

--- a/src/test/java/seedu/address/logic/commands/OpenCommissionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/OpenCommissionCommandTest.java
@@ -32,7 +32,7 @@ class OpenCommissionCommandTest {
     public void execute_noIndex_switchesTab() {
         model.selectCustomer(model.getSortedFilteredCustomerList().get(0));
         CommandResult result = assertDoesNotThrow(() -> new OpenCommissionCommand().execute(model));
-        assertEquals(result.getFeedbackToUser(), Messages.MESSAGE_OPEN_COMMISSION_TAB_SUCCESS);
+        assertEquals(result.getFeedbackToUser(), OpenCommissionCommand.MESSAGE_USAGE);
         assertEquals(model.getSelectedTab(), GuiTab.COMMISSION);
     }
 

--- a/src/test/java/seedu/address/logic/commands/OpenCustomerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/OpenCustomerCommandTest.java
@@ -81,7 +81,7 @@ public class OpenCustomerCommandTest {
     public void execute_noIndex_switchesTab() {
         model = new ModelManager();
         CommandResult result = assertDoesNotThrow(() -> new OpenCustomerCommand().execute(model));
-        assertEquals(result.getFeedbackToUser(), Messages.MESSAGE_OPEN_CUSTOMER_TAB_SUCCESS);
+        assertEquals(result.getFeedbackToUser(), OpenCustomerCommand.MESSAGE_USAGE);
         assertEquals(model.getSelectedTab(), GuiTab.CUSTOMER);
     }
 
@@ -105,14 +105,5 @@ public class OpenCustomerCommandTest {
 
         // different customer -> returns false
         assertFalse(openFirstCommand.equals(openSecondCommand));
-    }
-
-    /**
-     * Updates {@code model}'s filtered list to show no one.
-     */
-    private void showNoCustomer(Model model) {
-        model.updateFilteredCustomerList(p -> false);
-
-        assertTrue(model.getSortedFilteredCustomerList().isEmpty());
     }
 }


### PR DESCRIPTION
Display more useful CommandResult for opencom and opencus
- Previously, `opencus` and `opencom` without the provided `INDEX` will not mention how the command actually works with a provided `INDEX`.
- Displaying the message usage when typing `opencom` or `opencus` will make it much easier for the user.

Fixes #155