### PR TITLE
Fix `delcom` selectCustomer check and commission reference problem

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommissionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommissionCommand.java
@@ -37,10 +37,6 @@ public class DeleteCommissionCommand extends Command {
     @Override
     public CommandResult execute(Model model, Storage...storage) throws CommandException {
         requireNonNull(model);
-
-        if (!model.hasSelectedCustomer()) {
-            throw new CommandException(Messages.MESSAGE_NO_ACTIVE_CUSTOMER);
-        }
         List<Commission> lastShownList = model.getFilteredCommissionList();
         if (lastShownList == null || targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_COMMISSION_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/EditCustomerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCustomerCommand.java
@@ -88,7 +88,10 @@ public class EditCustomerCommand extends Command {
         Customer.CustomerBuilder customerBuilder = new Customer.CustomerBuilder(updatedName, updatedPhone,
                 updatedEmail, updatedTags).setCommissions(oldCommissions);
         updatedAddress.ifPresent(customerBuilder::setAddress);
-        return customerBuilder.build();
+
+        Customer updatedCustomer = customerBuilder.build();
+        updatedCustomer.setCommissionsCustomerReference();
+        return updatedCustomer;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCustomerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCustomerCommand.java
@@ -88,10 +88,7 @@ public class EditCustomerCommand extends Command {
         Customer.CustomerBuilder customerBuilder = new Customer.CustomerBuilder(updatedName, updatedPhone,
                 updatedEmail, updatedTags).setCommissions(oldCommissions);
         updatedAddress.ifPresent(customerBuilder::setAddress);
-
-        Customer updatedCustomer = customerBuilder.build();
-        updatedCustomer.setCommissionsCustomerReference();
-        return updatedCustomer;
+        return customerBuilder.build();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/commission/Commission.java
+++ b/src/main/java/seedu/address/model/commission/Commission.java
@@ -74,7 +74,11 @@ public class Commission {
         completionStatus = builder.status;
         tags = builder.tags;
         description = builder.description;
-        iterations = builder.iterations;
+        iterations = new UniqueIterationList();
+        builder.iterations.forEach(iteration -> {
+            iterations.add(new Iteration(iteration.getDate(), iteration.getDescription(), iteration.getImagePath(),
+                    iteration.getFeedback()));
+        });
         this.customer = customer;
     }
 

--- a/src/main/java/seedu/address/model/commission/Commission.java
+++ b/src/main/java/seedu/address/model/commission/Commission.java
@@ -27,7 +27,7 @@ public class Commission {
     private final Fee fee;
     private final Deadline deadline;
     private final CompletionStatus completionStatus;
-    private Customer customer;
+    private final Customer customer;
 
     // Data field
     private final UniqueIterationList iterations;
@@ -134,10 +134,6 @@ public class Commission {
 
     public Customer getCustomer() {
         return customer;
-    }
-
-    public void setCustomer(Customer customer) {
-        this.customer = customer;
     }
 
     public UniqueIterationList getIterations() {

--- a/src/main/java/seedu/address/model/commission/Commission.java
+++ b/src/main/java/seedu/address/model/commission/Commission.java
@@ -27,7 +27,7 @@ public class Commission {
     private final Fee fee;
     private final Deadline deadline;
     private final CompletionStatus completionStatus;
-    private final Customer customer;
+    private Customer customer;
 
     // Data field
     private final UniqueIterationList iterations;
@@ -134,6 +134,10 @@ public class Commission {
 
     public Customer getCustomer() {
         return customer;
+    }
+
+    public void setCustomer(Customer customer) {
+        this.customer = customer;
     }
 
     public UniqueIterationList getIterations() {

--- a/src/main/java/seedu/address/model/customer/Customer.java
+++ b/src/main/java/seedu/address/model/customer/Customer.java
@@ -44,8 +44,16 @@ public class Customer {
         phone = builder.phone;
         email = builder.email;
         tags = builder.tags;
-        commissions = builder.commissions;
         address = builder.address;
+        commissions = new UniqueCommissionList();
+        builder.commissions.forEach(commission -> {
+            commissions.add(new Commission.CommissionBuilder(
+                    commission.getTitle(),
+                    commission.getFee(),
+                    commission.getDeadline(),
+                    commission.getCompletionStatus(),
+                    commission.getTags()).setIterations(commission.getIterations()).build(this));
+        });
     }
 
     public Name getName() {

--- a/src/main/java/seedu/address/model/customer/Customer.java
+++ b/src/main/java/seedu/address/model/customer/Customer.java
@@ -209,12 +209,6 @@ public class Customer {
             && otherCustomer.commissions.equals(commissions);
     }
 
-    public void setCommissionsCustomerReference() {
-        for (Commission commission : commissions) {
-            commission.setCustomer(this);
-        }
-    }
-
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own

--- a/src/main/java/seedu/address/model/customer/Customer.java
+++ b/src/main/java/seedu/address/model/customer/Customer.java
@@ -209,6 +209,12 @@ public class Customer {
             && otherCustomer.commissions.equals(commissions);
     }
 
+    public void setCommissionsCustomerReference() {
+        for (Commission commission : commissions) {
+            commission.setCustomer(this);
+        }
+    }
+
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own

--- a/src/test/java/seedu/address/logic/commands/DeleteCommissionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommissionCommandTest.java
@@ -23,13 +23,7 @@ import seedu.address.model.commission.Commission;
  * {@code DeleteCommissionCommand}.
  */
 class DeleteCommissionCommandTest {
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-
-    @Test
-    public void execute_noSelectedCustomer_throwsCommandException() {
-        model.selectCustomer(null);
-        assertCommandFailure(new DeleteCommissionCommand(INDEX_FIRST), model, Messages.MESSAGE_NO_ACTIVE_CUSTOMER);
-    }
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void execute_validIndex_success() {


### PR DESCRIPTION
1. Remove selectedCustomer check in `delcom` to address bug reports that after `allcom`, the error message makes no sense
2. Doing so creates another bug. (actually it might possibly already be there. hmm) To replicate:
    1.  `editcus 1 t/edited`
    2. `allcom`
    3. `delcom 1`
    4. it looks ok here and the commission seems deleted in the public list
    5. `opencus 1`
    6. and you will see the commission is STILL THERE

This is because `editcus` creates a new customer object without updating commission references, while `delcom` deletes from the commission's OLD customer reference, so the new customer that is in the customer list does not receive the changes.

~Fix by making customer not final and updating references (which admittedly, feels kinda off)~

For defensive programming purposes: clone everything (credit to review comments below)