### PR TITLE
Bug Fixing

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedIteration.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedIteration.java
@@ -1,5 +1,6 @@
 package seedu.address.storage;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDate;
 
@@ -18,6 +19,7 @@ import seedu.address.model.iteration.IterationDescription;
 public class JsonAdaptedIteration {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Iteration's %s field is missing!";
+    public static final String MISSING_IMAGE_MESSAGE_FORMAT = "Iteration image could not be found!";
 
     private final LocalDate date;
     private final String description;
@@ -75,6 +77,10 @@ public class JsonAdaptedIteration {
                     Path.class.getSimpleName()));
         }
         Path modelImagePath = Path.of(path);
+
+        if (Files.notExists(modelImagePath)) {
+            throw new IllegalValueException(MISSING_IMAGE_MESSAGE_FORMAT);
+        }
 
         final Feedback modelFeedback = new Feedback(feedback);
 

--- a/src/main/resources/view/CustomerListCard.fxml
+++ b/src/main/resources/view/CustomerListCard.fxml
@@ -7,6 +7,7 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.scene.layout.Region?>
 
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
@@ -18,7 +19,12 @@
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
       <HBox spacing="5" alignment="CENTER_LEFT">
-        <Label fx:id="id" id="cell_id_label"/>
+        <Label fx:id="id" id="cell_id_label">
+          <minWidth>
+            <!-- Ensures that the label text is never truncated -->
+            <Region fx:constant="USE_PREF_SIZE" />
+          </minWidth>
+        </Label>
         <Label fx:id="name" text="\$first" id="cell_title_label"/>
         <VBox.margin>
           <Insets bottom="4"/>


### PR DESCRIPTION
- [x] Closes issue #188 
    Note: this fix is allowed according to-
    > Q: The UI text get truncated (or overflows) for certain inputs (or certain Windows sizes); can we fix them in v1.4? A: Only if the behavior hinders normal usage i.e., not showing the text fully/properly under normal usage can be considered an 'incorrect' behavior, and hence, a bug.

   The truncation of text hinders the user from seeing index and thus, they cannot perform some commands like `opencus INDEX` => incorrect behaviour.

- [x] Closes issue #189 (resets ArtBuddy if the saved image path in the JSON file is corrupted)