### PR TITLE
Model: add method to check same for selected customer

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCustomerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCustomerCommand.java
@@ -46,7 +46,7 @@ public class DeleteCustomerCommand extends Command {
         Customer selectedCustomer = model.getSelectedCustomer().getValue();
         Customer customerToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteCustomer(customerToDelete);
-        if (!selectedCustomer.isSameCustomer(customerToDelete)) {
+        if (!model.isSameCustomerAsSelectedCustomer(customerToDelete)) {
             model.selectCustomer(selectedCustomer);
         }
 

--- a/src/main/java/seedu/address/logic/commands/EditCustomerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCustomerCommand.java
@@ -109,7 +109,7 @@ public class EditCustomerCommand extends Command {
 
         model.setCustomer(customerToEdit, editedCustomer);
 
-        if (model.getSelectedCustomer().getValue().isSameCustomer(customerToEdit)) {
+        if (model.isSameCustomerAsSelectedCustomer(customerToEdit)) {
             model.selectCustomer(editedCustomer);
         }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -217,4 +217,6 @@ public interface Model {
      * Returns the selected tab.
      */
     GuiTab getSelectedTab();
+
+    boolean isSameCustomerAsSelectedCustomer(Customer customer);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -284,6 +285,16 @@ public class ModelManager implements Model {
     @Override
     public boolean hasSelectedCustomer() {
         return getSelectedCustomer().getValue() != null;
+    }
+
+    /**
+     * Returns whether the customer is the same as the selected customer, which is possibly null.
+     * @param customer Customer to compare selected customer to.
+     * @return Whether the customer is the same as the selected customer.
+     */
+    public boolean isSameCustomerAsSelectedCustomer(Customer customer) {
+        return Optional.ofNullable(getSelectedCustomer().getValue())
+                .map(selectedCustomer -> selectedCustomer.isSameCustomer(customer)).orElse(false);
     }
 
     //=========== Selected Commission =============================================================

--- a/src/test/java/seedu/address/model/ModelStub.java
+++ b/src/test/java/seedu/address/model/ModelStub.java
@@ -155,6 +155,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public boolean isSameCustomerAsSelectedCustomer(Customer customer) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public ObservableObject<Commission> getSelectedCommission() {
         throw new AssertionError("This method should not be called.");
     }


### PR DESCRIPTION
Previously, `addcus` would select a customer, while `editcus` and `delcus` would by definition already have one customer - so `selectedCustomer` could be safely assumed to be non-null.

`allcom` has violated this assumption, so the code must change for that possibility.

This PR adds a method to check if selectedCustomer is the same customer and if no selectedCustomer, return false. 

Closes #197 