### PR TITLE
Fix bug where sorted list update is not triggered when predicate is changed

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -42,6 +42,8 @@ public class ModelManager implements Model {
 
     private GuiTab selectedTab = GuiTab.CUSTOMER;
 
+    private Comparator<Customer> customerComparator = CUSTOMER_NAME_COMPARATOR;
+
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
      */
@@ -232,6 +234,7 @@ public class ModelManager implements Model {
     @Override
     public void updateSortedCustomerList(Comparator<Customer> comparator) {
         requireNonNull(comparator);
+        this.customerComparator = comparator;
         sortedFilteredCustomers.setComparator(comparator);
     }
 
@@ -259,6 +262,7 @@ public class ModelManager implements Model {
                 .noneMatch(selectedCommission.getValue()::isSameCommission)) {
             selectCommission(getFilteredCommissionList().get(0));
         }
+        updateSortedCustomerList(customerComparator);
     }
 
     //=========== Filtered Commission List Statistic Aggregator ==================================================


### PR DESCRIPTION
Currently, the list that is displayed is based on the sorted + filtered customer list, so updating the filtered customer list with the same customer will not cause the sorted list to update and that has to be explicitly triggered.

Fixes #226, should fix #227 as well