### PR TITLE
Model: update global commission list on customer update

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -92,6 +92,8 @@ public class AddressBook implements ReadOnlyAddressBook {
     public void setCustomer(Customer target, Customer editedCustomer) {
         requireNonNull(editedCustomer);
         customers.setCustomer(target, editedCustomer);
+        target.getCommissionList().forEach(allCommissions::remove);
+        editedCustomer.getCommissionList().forEach(allCommissions::add);
     }
 
     /**


### PR DESCRIPTION
In one of my previous PRs, #194, I cloned each commission on customer update.

The global commission list was not updated, and I think this is causing the issue.

I observe the problem isn't there if you edited the customer's tags instead of name - this is likely because of the `Commission#equals()` using `isSameCustomer()` check which checks the Customer's name only.

When deleting the new commission off the global commission list, the corresponding commission has an old, different customer name and ArtBuddy can't find it to remove, causing the error.

Closes #226 and #227 